### PR TITLE
fix: 修复预测性压缩器路径与安装文档不一致

### DIFF
--- a/scripts/predictive-compressor.sh
+++ b/scripts/predictive-compressor.sh
@@ -5,7 +5,7 @@
 set -e
 
 SESSIONS_DIR="$HOME/.openclaw/agents/main/sessions"
-COMPRESSOR="$HOME/context-compressor-v5.sh"
+COMPRESSOR="$HOME/bin/context-compressor-v5.sh"
 METRICS_FILE="/tmp/predictive-metrics.json"
 
 # 初始化指标


### PR DESCRIPTION
## 🐛 问题描述

安装文档中要求：
```bash
cp scripts/*.sh ~/bin/
```

但 `predictive-compressor.sh` 中的路径是：
```bash
COMPRESSOR="$HOME/context-compressor-v5.sh"
```

这导致按照文档安装后，预测性压缩引擎无法找到实际的压缩器脚本。

## ✅ 修复内容

将路径修改为：
```bash
COMPRESSOR="$HOME/bin/context-compressor-v5.sh"
```

与安装文档保持一致。

## 📋 测试验证

- [x] 本地测试通过
- [x] 预测分析正常执行
- [x] 路径引用正确