### PR TITLE
fix: Issue #69 + #70 - TF-IDF fallback + 增量压缩不分块

### DIFF
--- a/skill/lobster-press/scripts/incremental_compressor.py
+++ b/skill/lobster-press/scripts/incremental_compressor.py
@@ -152,6 +152,7 @@ class IncrementalCompressor:
         """开始新的压缩
         
         Issue #65 修复：集成真正的压缩逻辑
+        Issue #70 修复：移除分块压缩，直接压缩整个文件
         """
         # 读取会话文件
         try:
@@ -175,52 +176,32 @@ class IncrementalCompressor:
         
         self.progress_manager.save_progress(progress)
         
-        # 处理消息（Issue #65 修复：分块压缩）
+        # Issue #70 修复：直接压缩整个文件，不分块
         try:
             from lobster_press_v124 import LobsterPressV124
             
             engine = LobsterPressV124(strategy=strategy)
-            chunk_size = 500  # 每个压缩块的大小
-            all_compressed = []
             
-            # 分块处理
-            for chunk_start in range(0, total_messages, chunk_size):
-                chunk_end = min(chunk_start + chunk_size, total_messages)
-                chunk_lines = lines[chunk_start:chunk_end]
-                
-                # 准备 chunk 内容
-                chunk_content = ''.join(chunk_lines)
-                
-                # 调用真正的压缩逻辑
-                compressed_content, stats = engine.compress(chunk_content)
-                
-                # 解析压缩后的内容
-                for line in compressed_content.strip().split('\n'):
-                    if line.strip():
-                        all_compressed.append(json.loads(line))
-                
-                # 更新进度
-                progress.processed_messages = chunk_end
-                progress.last_checkpoint = datetime.now().isoformat()
-                
-                # 保存检查点
-                if chunk_end % (self.checkpoint_size * 5) == 0:
-                    self._save_checkpoint(progress, all_compressed)
+            # 准备完整内容
+            content = ''.join(lines)
             
-            # 完成压缩：写入最终结果
+            # 调用真正的压缩逻辑（一次性压缩）
+            compressed_content, stats = engine.compress(content)
+            
+            # 写入最终结果
             with open(output_file, 'w', encoding='utf-8') as f:
-                for msg in all_compressed:
-                    f.write(json.dumps(msg, ensure_ascii=False) + '\n')
+                f.write(compressed_content)
             
             # 更新进度状态
             progress.status = "completed"
+            progress.processed_messages = total_messages
             self.progress_manager.save_progress(progress)
             
             # 删除部分文件
             if os.path.exists(partial_file):
                 os.unlink(partial_file)
             
-            return True, f"压缩完成: {total_messages} 条消息 -> {len(all_compressed)} 条消息"
+            return True, f"压缩完成: {total_messages} 条消息 -> {stats.compressed_lines} 条消息"
         
         except Exception as e:
             progress.status = "failed"
@@ -235,60 +216,39 @@ class IncrementalCompressor:
                            strategy: str) -> Tuple[bool, str]:
         """恢复压缩
         
-        Issue #65 修复：集成真正的压缩逻辑
+        Issue #70 修复：移除分块压缩，直接压缩整个文件
         """
         print(f"🔄 恢复压缩: {progress.session_id} ({progress.progress_percent:.1f}%)")
         
-        # 读取已处理的部分
-        processed = []
-        if os.path.exists(progress.partial_result_path):
-            try:
-                with open(progress.partial_result_path, 'r', encoding='utf-8') as f:
-                    for line in f:
-                        if line.strip():
-                            processed.append(json.loads(line))
-            except Exception as e:
-                print(f"⚠️ 无法读取部分结果: {e}")
-        
-        # 读取剩余消息
+        # 读取会话文件
         try:
             with open(session_file, 'r', encoding='utf-8') as f:
-                lines = f.readlines()
+                content = f.read()
         except Exception as e:
             return False, f"无法读取会话文件: {e}"
         
-        # 跳过已处理的消息
-        remaining_lines = lines[progress.processed_messages:]
-        
-        # 继续处理（Issue #65 修复：使用真正的压缩逻辑）
+        # Issue #70 修复：直接压缩整个文件
         try:
             from lobster_press_v124 import LobsterPressV124
             
             engine = LobsterPressV124(strategy=strategy)
             
-            # 处理剩余消息
-            if remaining_lines:
-                chunk_content = ''.join(remaining_lines)
-                compressed_content, stats = engine.compress(chunk_content)
-                
-                # 解析压缩后的消息
-                for line in compressed_content.strip().split('\n'):
-                    if line.strip():
-                        processed.append(json.loads(line))
+            # 一次性压缩整个文件
+            compressed_content, stats = engine.compress(content)
             
-            # 完成：写入最终结果
+            # 写入最终结果
             with open(output_file, 'w', encoding='utf-8') as f:
-                for msg in processed:
-                    f.write(json.dumps(msg, ensure_ascii=False) + '\n')
+                f.write(compressed_content)
             
             progress.status = "completed"
             progress.processed_messages = progress.total_messages
+            progress.compressed_messages = stats.compressed_lines
             self.progress_manager.save_progress(progress)
             
             if os.path.exists(progress.partial_result_path):
                 os.unlink(progress.partial_result_path)
             
-            return True, f"压缩完成: {progress.total_messages} 条消息"
+            return True, f"压缩完成: {progress.total_messages} 条消息 -> {stats.compressed_lines} 条消息"
         
         except Exception as e:
             progress.status = "failed"

--- a/skill/lobster-press/scripts/tfidf_scorer.py
+++ b/skill/lobster-press/scripts/tfidf_scorer.py
@@ -210,10 +210,18 @@ class TFIDFScorer:
         
         # Layer 1: TF-IDF 基础分
         tfidf_score = 0.0
-        if tokens and self.idf_cache:
-            # 计算该消息的平均 IDF 值
-            idf_values = [self.idf_cache.get(t, 1.0) for t in tokens]
-            tfidf_score = sum(idf_values) / len(idf_values) * 10  # 缩放到 0-100
+        if tokens:
+            if self.idf_cache:
+                # 计算该消息的平均 IDF 值
+                idf_values = [self.idf_cache.get(t, 1.0) for t in tokens]
+                tfidf_score = sum(idf_values) / len(idf_values) * 10  # 缩放到 0-100
+            else:
+                # Issue #69 修复：fallback 到 TF（无语料库时的最佳估算）
+                tf = Counter(tokens)
+                max_tf = max(tf.values())
+                # 使用相对 TF 归一化
+                tf_values = [tf[t] / max_tf for t in tokens]
+                tfidf_score = sum(tf_values) / len(tf_values) * 10  # 缩放到 0-100
         
         # Layer 2: 结构性信号加成
         structural_bonus = self._compute_structural_bonus(content)


### PR DESCRIPTION
## 问题描述

同时修复了 Issue #69 和 Issue #70 两个低级错误。

**Issue #69:** TFIDFScorer 单独调用时评分恒为 0
**Issue #70:** IncrementalCompressor 分块压缩导致 summary 重复

---

## 修复内容

### Issue #69 修复

**问题：**
- `TFIDFScorer.score_message()` 单独调用时 `idf_cache` 为空
- 导致 `tfidf_score` 恒为 0

**修复：**
- 添加 fallback 到 TF (无语料库时的最佳估算)
- 使用相对 TF 归一化代替 IDF

**验证：**
- ✅ 无语料库时评分: 5.32 (fallback 生效)
- ✅ 有语料库后评分: 13-15 (正常)

---

### Issue #70 修复

**问题：**
- `IncrementalCompressor` 分块压缩导致 summary 消息重复
- 每个 chunk 生成一个 summary，导致 10 个 chunk = 10 条 summary
- 头文件 (`type=session`) 也被多次写入

**修复：**
- 移除分块逻辑，直接压缩整个文件
- 简化代码，避免拼接错误

**验证：**
- ✅ 50 条消息 -> 36 条消息
- ✅ Summary 消息数: 1 (不再重复)

---

## 测试验证

### Issue #69 验证
```bash
无语料库时 TF-IDF 评分: 5.32
✅ Issue #69 修复验证: fallback 到 TF 生效

有语料库后评分:
  第一条消息 -> 13.77
  第二条消息 -> 14.74

✅ Issue #69 完全修复验证通过
```

### Issue #70 验证
```bash
压缩成功: 压缩完成: 50 条消息 -> 36 条消息
总行数: 36
Summary 消息数: 1
✅ Issue #70 验证通过
```

---

## 质量保证

- ✅ 语法检查通过
- ✅ 功能测试通过
- ✅ 所有验证通过

---

## Closes

Closes #69
Closes #70