### PR TITLE
feat: v2.5.0 Week 1 - Schema 升级 + pipeline 模块

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -47,6 +47,11 @@ class LobsterDatabase:
                 token_count INTEGER DEFAULT 0,
                 created_at TEXT NOT NULL,
                 metadata TEXT,
+                -- v2.5.0 新增字段
+                msg_type TEXT DEFAULT 'unknown',
+                tfidf_score REAL DEFAULT 0.0,
+                structural_bonus REAL DEFAULT 0.0,
+                compression_exempt INTEGER DEFAULT 0,
                 FOREIGN KEY (conversation_id) REFERENCES conversations(conversation_id)
             );
         """)
@@ -163,6 +168,30 @@ class LobsterDatabase:
         """)
         
         self.conn.commit()
+        
+        # v2.5.0 迁移
+        self.migrate_v25()
+    
+    def migrate_v25(self):
+        """v2.5.0 schema 迁移
+        
+        为已有数据库添加新字段（向前兼容）
+        """
+        migrations = [
+            "ALTER TABLE messages ADD COLUMN msg_type TEXT DEFAULT 'unknown'",
+            "ALTER TABLE messages ADD COLUMN tfidf_score REAL DEFAULT 0.0",
+            "ALTER TABLE messages ADD COLUMN structural_bonus REAL DEFAULT 0.0",
+            "ALTER TABLE messages ADD COLUMN compression_exempt INTEGER DEFAULT 0",
+        ]
+        
+        for sql in migrations:
+            try:
+                self.cursor.execute(sql)
+            except sqlite3.OperationalError:
+                # 字段已存在，跳过
+                pass
+        
+        self.conn.commit()
     
     # ==================== 消息操作 ====================
     
@@ -170,7 +199,7 @@ class LobsterDatabase:
         """保存消息（永久存储）
         
         Args:
-            message: 消息对象
+            message: 消息对象（v2.5.0 支持 msg_type, tfidf_score, compression_exempt）
         
         Returns:
             message_id
@@ -184,11 +213,19 @@ class LobsterDatabase:
         created_at = message.get('timestamp') or datetime.utcnow().isoformat()
         metadata = json.dumps(message, ensure_ascii=False)
         
+        # v2.5.0 新字段
+        msg_type = message.get('msg_type', 'unknown')
+        tfidf_score = message.get('tfidf_score', 0.0)
+        structural_bonus = message.get('structural_bonus', 0.0)
+        compression_exempt = 1 if message.get('compression_exempt', False) else 0
+        
         self.cursor.execute("""
             INSERT OR REPLACE INTO messages 
-            (message_id, conversation_id, seq, role, content, token_count, created_at, metadata)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-        """, (message_id, conversation_id, seq, role, content, token_count, created_at, metadata))
+            (message_id, conversation_id, seq, role, content, token_count, created_at, metadata,
+             msg_type, tfidf_score, structural_bonus, compression_exempt)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """, (message_id, conversation_id, seq, role, content, token_count, created_at, metadata,
+              msg_type, tfidf_score, structural_bonus, compression_exempt))
         
         # 更新 FTS 索引
         self.cursor.execute("""
@@ -492,7 +529,8 @@ class LobsterDatabase:
         """
         if table == 'messages':
             columns = ['id', 'message_id', 'conversation_id', 'seq', 'role', 
-                      'content', 'token_count', 'created_at', 'metadata']
+                      'content', 'token_count', 'created_at', 'metadata',
+                      'msg_type', 'tfidf_score', 'structural_bonus', 'compression_exempt']
         elif table == 'summaries':
             columns = ['id', 'summary_id', 'conversation_id', 'kind', 'depth',
                       'content', 'token_count', 'earliest_at', 'latest_at',

--- a/src/pipeline/__init__.py
+++ b/src/pipeline/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+"""
+LobsterPress Pipeline - v2.5.0 智能压缩流水线
+
+包含：
+- TFIDFScorer: 评分器
+- SemanticDeduplicator: 去重器
+- BatchImporter: 历史数据迁移（待实现）
+"""
+
+from .tfidf_scorer import TFIDFScorer, ScoredMessage, EXEMPT_TYPES
+from .semantic_dedup import SemanticDeduplicator
+
+__all__ = [
+    'TFIDFScorer',
+    'ScoredMessage',
+    'EXEMPT_TYPES',
+    'SemanticDeduplicator',
+]

--- a/src/pipeline/semantic_dedup.py
+++ b/src/pipeline/semantic_dedup.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+语义去重器 v2.5.0（标准化接口）
+从 scripts/semantic_dedup.py 提升，适配 v2.5.0 架构
+
+新增：
+- 支持 compression_exempt 消息跳过去重
+- 标准化接口 deduplicate()
+
+Author: LobsterPress Team
+Version: v2.5.0
+"""
+
+import math
+from typing import List, Tuple, Set
+from collections import Counter
+
+try:
+    from .tfidf_scorer import ScoredMessage
+except ImportError:
+    # 直接运行时的导入
+    from tfidf_scorer import ScoredMessage
+
+
+class SemanticDeduplicator:
+    """v2.5.0 语义去重器
+    
+    基于 TF 向量余弦相似度，阈值 0.82，零 API 成本。
+    
+    新增：
+    - compression_exempt=True 的消息跳过去重，保证关键信息不被合并
+    """
+    
+    def __init__(self, threshold: float = 0.82):
+        """初始化去重器
+        
+        Args:
+            threshold: 重复阈值（0-1）
+        """
+        self.threshold = threshold
+        self.min_tokens = 3
+    
+    def deduplicate(self, scored: List[ScoredMessage]) -> Tuple[List[ScoredMessage], List[str]]:
+        """去重
+        
+        Args:
+            scored: ScoredMessage 列表（已评分）
+        
+        Returns:
+            (保留的消息列表, 被删除的消息ID列表)
+            
+        Note:
+            compression_exempt=True 的消息强制保留，不参与去重
+        """
+        to_remove: Set[str] = set()
+        n = len(scored)
+        
+        # 缓存 token 列表
+        tokens_cache = {msg.id: msg.tokens if msg.tokens else self._tokenize(msg.content) 
+                        for msg in scored}
+        
+        for i in range(n):
+            msg_a = scored[i]
+            
+            if msg_a.id in to_remove:
+                continue
+            
+            # ✨ 豁免消息跳过去重
+            if msg_a.compression_exempt:
+                continue
+            
+            tokens_a = tokens_cache[msg_a.id]
+            if len(tokens_a) < self.min_tokens:
+                continue
+            
+            for j in range(i + 1, n):
+                msg_b = scored[j]
+                
+                if msg_b.id in to_remove:
+                    continue
+                
+                # ✨ 豁免消息跳过去重
+                if msg_b.compression_exempt:
+                    continue
+                
+                tokens_b = tokens_cache[msg_b.id]
+                if len(tokens_b) < self.min_tokens:
+                    continue
+                
+                # 计算余弦相似度
+                sim = self._cosine(tokens_a, tokens_b)
+                
+                if sim > self.threshold:
+                    # 保留分数更高的
+                    if msg_a.final_score >= msg_b.final_score:
+                        to_remove.add(msg_b.id)
+                    else:
+                        to_remove.add(msg_a.id)
+                        break  # i 被删除，不需要继续比较
+        
+        kept = [m for m in scored if m.id not in to_remove]
+        removed_ids = list(to_remove)
+        
+        return kept, removed_ids
+    
+    def _tokenize(self, text: str) -> List[str]:
+        """简单分词（用于去重）
+        
+        Args:
+            text: 输入文本
+        
+        Returns:
+            Token 列表
+        """
+        import re
+        tokens = re.findall(r'[a-zA-Z]+', text.lower())
+        chinese = re.findall(r'[\u4e00-\u9fff]', text)
+        for i in range(len(chinese) - 1):
+            tokens.append(chinese[i] + chinese[i + 1])
+        return tokens
+    
+    def _cosine(self, a: List[str], b: List[str]) -> float:
+        """计算余弦相似度（基于 TF 向量）
+        
+        Args:
+            a: 消息 A 的 token 列表
+            b: 消息 B 的 token 列表
+        
+        Returns:
+            相似度（0-1）
+        """
+        if not a or not b:
+            return 0.0
+        
+        tf_a = Counter(a)
+        tf_b = Counter(b)
+        
+        all_terms = set(tf_a) | set(tf_b)
+        
+        dot_product = sum(tf_a.get(t, 0) * tf_b.get(t, 0) for t in all_terms)
+        
+        norm_a = math.sqrt(sum(v ** 2 for v in tf_a.values()))
+        norm_b = math.sqrt(sum(v ** 2 for v in tf_b.values()))
+        
+        if norm_a == 0 or norm_b == 0:
+            return 0.0
+        
+        return dot_product / (norm_a * norm_b)
+
+
+# ==================== 测试代码 ====================
+
+if __name__ == "__main__":
+    import sys
+    from pathlib import Path
+    # 添加父目录到 sys.path，支持相对导入
+    sys.path.insert(0, str(Path(__file__).parent.parent))
+    from pipeline.tfidf_scorer import TFIDFScorer
+    
+    print("🧪 测试 SemanticDeduplicator v2.5.0\n")
+    
+    scorer = TFIDFScorer()
+    deduper = SemanticDeduplicator(threshold=0.82)
+    
+    # 测试消息
+    test_messages = [
+        {"id": "m1", "role": "user", "content": "我们决定采用 PostgreSQL", "timestamp": 0},
+        {"id": "m2", "role": "user", "content": "我们决定使用 PostgreSQL 数据库", "timestamp": 1},
+        {"id": "m3", "role": "user", "content": "Python 如何连接数据库", "timestamp": 2},
+        {"id": "m4", "role": "user", "content": "Python 怎么连接数据库", "timestamp": 3},
+    ]
+    
+    # 评分
+    scored = scorer.score_and_tag(test_messages)
+    
+    print("评分结果:")
+    for msg in scored:
+        exempt = "✅" if msg.compression_exempt else "❌"
+        print(f"  {msg.id}: [{msg.msg_type}] {exempt} 分数={msg.final_score:.1f}")
+    
+    print("\n去重:")
+    kept, removed = deduper.deduplicate(scored)
+    
+    print(f"  保留: {len(kept)} 条")
+    print(f"  删除: {len(removed)} 条")
+    
+    if removed:
+        print(f"  被删除的 ID: {removed}")
+    
+    print("\n✅ 测试完成")

--- a/src/pipeline/tfidf_scorer.py
+++ b/src/pipeline/tfidf_scorer.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+TF-IDF 评分器 v2.5.0（标准化接口）
+从 scripts/tfidf_scorer.py 提升，适配 v2.5.0 架构
+
+新增：
+- score_and_tag() 批量接口
+- compression_exempt 字段
+- EXEMPT_TYPES 定义
+
+Author: LobsterPress Team
+Version: v2.5.0
+"""
+
+import re
+import math
+import time
+from datetime import datetime
+from collections import Counter
+from typing import List, Dict, Union
+from dataclasses import dataclass
+
+
+# 压缩豁免的消息类型（这些类型的消息不应被 DAG 折叠）
+EXEMPT_TYPES = {"decision", "config", "code", "error"}
+
+
+def parse_timestamp(ts: Union[str, int, float, None]) -> float:
+    """解析时间戳（支持 ISO 8601 和数值格式）
+    
+    Args:
+        ts: 时间戳（字符串、数值或 None）
+    
+    Returns:
+        Unix 时间戳（秒）
+    """
+    if ts is None:
+        return 0.0
+    
+    if isinstance(ts, (int, float)):
+        return max(0.0, float(ts)) if ts >= 0 else 0.0
+    
+    if isinstance(ts, str):
+        try:
+            return float(ts)
+        except ValueError:
+            pass
+        
+        iso_formats = [
+            "%Y-%m-%dT%H:%M:%SZ",
+            "%Y-%m-%dT%H:%M:%S.%fZ",
+            "%Y-%m-%dT%H:%M:%S%z",
+            "%Y-%m-%dT%H:%M:%S.%f%z",
+            "%Y-%m-%dT%H:%M:%S",
+            "%Y-%m-%dT%H:%M:%S.%f",
+            "%Y-%m-%d %H:%M:%S",
+        ]
+        
+        for fmt in iso_formats:
+            try:
+                dt = datetime.strptime(ts, fmt)
+                return dt.timestamp()
+            except ValueError:
+                continue
+        
+        return 0.0
+    
+    return 0.0
+
+
+@dataclass
+class ScoredMessage:
+    """评分后的消息（v2.5.0 标准格式）"""
+    id: str
+    role: str
+    content: str
+    timestamp: float
+    msg_type: str = "unknown"
+    tfidf_score: float = 0.0
+    structural_bonus: float = 0.0
+    time_decay: float = 0.0
+    final_score: float = 0.0
+    compression_exempt: bool = False
+    tokens: List[str] = None
+    
+    def __post_init__(self):
+        if self.tokens is None:
+            self.tokens = []
+
+
+class TFIDFScorer:
+    """v2.5.0 标准化评分器
+    
+    三层叠加评分：
+    - Layer 1: TF-IDF（词汇稀有度）
+    - Layer 2: 结构性信号（规则）
+    - Layer 3: 时间衰减
+    
+    新增：
+    - compression_exempt 字段（基于 msg_type 判断）
+    - score_and_tag() 批量接口
+    """
+    
+    STRUCTURAL_SIGNALS = [
+        (+30, [r'```', r'`[^`]+`']),
+        (+25, [r'error|exception|bug|报错|失败']),
+        (+20, [r'决定|采用|chosen|will use|就用']),
+        (+18, [r'config|host|port|key|secret|配置']),
+        (+15, [r'https?://', r'www\.']),
+        (+12, [r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}']),
+        (+10, [r'问题|question|如何|怎么|why']),
+        (-15, [r'^(好的|ok|嗯|👍|谢谢|got it|嗯嗯|哦哦)$']),
+        (-10, [r'^(好|是|对|ok)$']),
+    ]
+    
+    def __init__(self):
+        """初始化评分器"""
+        self.idf_cache: Dict[str, float] = {}
+        self.corpus_tokens: List[List[str]] = []
+    
+    def tokenize(self, text: str) -> List[str]:
+        """分词（支持中文 bi-gram）
+        
+        Args:
+            text: 输入文本
+        
+        Returns:
+            Token 列表
+        """
+        tokens = []
+        
+        # 英文单词
+        english_words = re.findall(r'[a-zA-Z]+', text.lower())
+        tokens.extend(english_words)
+        
+        # 数字
+        numbers = re.findall(r'\d+', text)
+        tokens.extend(numbers)
+        
+        # 中文 bi-gram
+        chinese_chars = re.findall(r'[\u4e00-\u9fff]', text)
+        for i in range(len(chinese_chars) - 1):
+            bi_gram = chinese_chars[i] + chinese_chars[i + 1]
+            tokens.append(bi_gram)
+        
+        # 单字也保留
+        tokens.extend(chinese_chars)
+        
+        return tokens
+    
+    def compute_idf(self, corpus: List[List[str]]) -> Dict[str, float]:
+        """计算 IDF 值
+        
+        Args:
+            corpus: 语料库（每个文档的 token 列表）
+        
+        Returns:
+            词到 IDF 值的映射
+        """
+        N = len(corpus)
+        if N == 0:
+            return {}
+        
+        df = Counter()
+        for doc in corpus:
+            for term in set(doc):
+                df[term] += 1
+        
+        idf = {}
+        for term, count in df.items():
+            idf[term] = math.log((N + 1) / (count + 1)) + 1
+        
+        return idf
+    
+    def score_and_tag(self, messages: List[Dict]) -> List[ScoredMessage]:
+        """批量评分并打标签（v2.5.0 核心接口）
+        
+        供 IncrementalCompressor 在入库前调用
+        
+        Args:
+            messages: 原始消息列表，每条格式 {id, role, content, timestamp}
+        
+        Returns:
+            ScoredMessage 列表，含 msg_type 和 compression_exempt
+        """
+        # 先构建语料库并计算 IDF
+        self.corpus_tokens = []
+        for msg in messages:
+            content = msg.get("content", "")
+            if isinstance(content, list):
+                # 提取文本内容
+                texts = []
+                for block in content:
+                    if isinstance(block, dict) and block.get('type') == 'text':
+                        texts.append(block.get('text', ''))
+                content = ' '.join(texts)
+            
+            tokens = self.tokenize(str(content))
+            self.corpus_tokens.append(tokens)
+        
+        self.idf_cache = self.compute_idf(self.corpus_tokens)
+        
+        # 逐条评分
+        results = []
+        for i, msg in enumerate(messages):
+            content = msg.get("content", "")
+            if isinstance(content, list):
+                texts = []
+                for block in content:
+                    if isinstance(block, dict) and block.get('type') == 'text':
+                        texts.append(block.get('text', ''))
+                content = ' '.join(texts)
+            else:
+                content = str(content)
+            
+            timestamp = msg.get("timestamp", 0)
+            role = msg.get("role", "user")
+            
+            # 解析时间戳
+            ts = parse_timestamp(timestamp)
+            
+            # 分词
+            tokens = self.corpus_tokens[i]
+            
+            # Layer 1: TF-IDF 基础分
+            tfidf_score = 0.0
+            if tokens and self.idf_cache:
+                idf_values = [self.idf_cache.get(t, 1.0) for t in tokens]
+                tfidf_score = sum(idf_values) / len(idf_values) * 10
+            
+            # Layer 2: 结构性信号加成
+            structural_bonus = self._compute_structural_bonus(content)
+            
+            # Layer 3: 时间衰减
+            time_decay = 0.0
+            if ts > 0:
+                age_hours = (time.time() - ts) / 3600
+                if age_hours > 0:
+                    time_decay = -min(15, age_hours * 0.3)
+            
+            # 最终分数
+            final_score = max(0, tfidf_score + structural_bonus + time_decay)
+            
+            # 判断消息类型
+            msg_type = self._classify_message(content)
+            
+            # 判断是否豁免压缩
+            compression_exempt = msg_type in EXEMPT_TYPES
+            
+            results.append(ScoredMessage(
+                id=msg.get("id", f"msg_{i}"),
+                role=role,
+                content=content,
+                timestamp=ts,
+                msg_type=msg_type,
+                tfidf_score=round(tfidf_score, 2),
+                structural_bonus=round(structural_bonus, 2),
+                time_decay=round(time_decay, 2),
+                final_score=round(final_score, 2),
+                compression_exempt=compression_exempt,
+                tokens=tokens,
+            ))
+        
+        return results
+    
+    def score_messages(self, messages: List[Dict]) -> List[ScoredMessage]:
+        """对消息列表评分（兼容旧接口）
+        
+        Args:
+            messages: 消息列表
+        
+        Returns:
+            评分后的消息列表
+        """
+        return self.score_and_tag(messages)
+    
+    def _compute_structural_bonus(self, content: str) -> float:
+        """计算结构性信号加成
+        
+        Args:
+            content: 消息内容
+        
+        Returns:
+            结构性加成分数
+        """
+        total_bonus = 0.0
+        content_lower = content.lower()
+        
+        for bonus, patterns in self.STRUCTURAL_SIGNALS:
+            for pattern in patterns:
+                if re.search(pattern, content_lower, re.IGNORECASE):
+                    total_bonus += bonus
+                    break
+        
+        return total_bonus
+    
+    def _classify_message(self, content: str) -> str:
+        """分类消息类型
+        
+        Args:
+            content: 消息内容
+        
+        Returns:
+            消息类型
+        """
+        content_lower = content.lower()
+        
+        if re.search(r'决定|采用|chosen|will use|就用|确定', content_lower):
+            return "decision"
+        
+        if re.search(r'error|exception|bug|报错|失败', content_lower):
+            return "error"
+        
+        if re.search(r'config|host|port|key|secret|配置|设置', content_lower):
+            return "config"
+        
+        if re.search(r'```|`[^`]+`|function|def |class ', content_lower):
+            return "code"
+        
+        if re.search(r'\?|？|如何|怎么|为什么|why|how', content_lower):
+            return "question"
+        
+        if re.search(r'^(好的|ok|嗯|👍|谢谢|got it|嗯嗯|哦哦|好|是|对)$', content_lower.strip()):
+            return "chitchat"
+        
+        return "unknown"
+
+
+# ==================== 测试代码 ====================
+
+if __name__ == "__main__":
+    print("🧪 测试 TFIDFScorer v2.5.0\n")
+    
+    scorer = TFIDFScorer()
+    
+    # 测试消息
+    test_messages = [
+        {"id": "m1", "role": "user", "content": "我们决定采用 React + Node.js 方案", "timestamp": 0},
+        {"id": "m2", "role": "user", "content": "好的", "timestamp": 0},
+        {"id": "m3", "role": "assistant", "content": "```python\ndef hello(): pass\n```", "timestamp": 0},
+        {"id": "m4", "role": "user", "content": "配置 host=192.168.1.1 port=8080", "timestamp": 0},
+        {"id": "m5", "role": "user", "content": "报错：Connection refused", "timestamp": 0},
+    ]
+    
+    scored = scorer.score_and_tag(test_messages)
+    
+    print(f"{'ID':<5} {'类型':<10} {'豁免':<6} {'分数':<8} 内容（前40字）")
+    print("-" * 80)
+    for msg in scored:
+        exempt = "✅" if msg.compression_exempt else "❌"
+        print(f"{msg.id:<5} {msg.msg_type:<10} {exempt:<6} {msg.final_score:<8.1f} {msg.content[:40]}")
+    
+    print("\n✅ 测试完成")


### PR DESCRIPTION
## 📋 改动概述

实施 Issue #90 - v2.5.0 融合升级方案（Week 1）

### ✅ 已完成

#### Step 1: 数据库 Schema 升级
- `messages` 表新增 4 个字段：
  - `msg_type` (decision/code/error/config/question/chitchat)
  - `tfidf_score` (TF-IDF 基础分)
  - `structural_bonus` (结构性加成)
  - `compression_exempt` (压缩豁免标志)
- 添加 `migrate_v25()` 迁移函数（向前兼容）
- 更新 `save_message()` 支持新字段

#### Step 2: pipeline/tfidf_scorer.py
- 从 scripts/tfidf_scorer.py 提升为标准模块
- 新增 `score_and_tag()` 批量接口
- 支持 `compression_exempt` 字段（基于 msg_type 判断）
- 定义 `EXEMPT_TYPES = {decision, config, code, error}`

#### Step 3: pipeline/semantic_dedup.py
- 从 scripts/semantic_dedup.py 提升为标准模块
- 支持 `ScoredMessage` dataclass
- 豁免消息（compression_exempt=True）跳过去重

### 🧪 测试结果

```bash
$ python3 src/database.py
✅ 数据库初始化成功
✅ 保存消息: msg_test123
✅ Schema 迁移正常

$ python3 src/pipeline/tfidf_scorer.py
ID    类型         豁免     分数
m1    decision   ✅      41.0
m2    chitchat   ❌      6.0
m3    code       ✅      51.0
m4    config     ✅      51.0
m5    error      ✅      46.0

$ python3 src/pipeline/semantic_dedup.py
去重: 保留 4 条, 删除 0 条（豁免消息不参与去重）
```

### 📊 预期收益

- **关键信息保留率**: 85% → 99%（豁免机制）
- **零 API 成本**: 60-75% 区间仅本地去重
- **搜索相关性**: 待 Week 3 实施 TF-IDF 重排序

### 🗓️ 下一步（Week 2）

- IncrementalCompressor 集成流水线
- lobster_grep 增加 TF-IDF 重排序
- 完善集成测试

---

Ref: #90