### PR TITLE
feat: 双模式插件支持 (Issue #183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@
 格式基于 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.0.0/)，
 并且本项目遵循 [语义化版本](https://semver.org/lang/zh-CN/)。
 
+## [4.0.38] - 2026-03-22
+
+### Added (Issue #183: 双模式插件)
+- 🦞 **Lifecycle Hooks**: 新增 `before_agent_start` 和 `agent_end` hooks
+  - 作为 ContextEngine 的降级方案
+  - 参考 MemOS OpenClaw Plugin 实现
+  - 立即可用，无需等待 OpenClaw Gateway 更新
+- 🔄 **双模式支持**: 同时支持 `lifecycle` 和 `context-engine` 两种模式
+  - ContextEngine 模式（未来）：`afterTurn` 自动压缩
+  - Lifecycle 模式（现在）：`before_agent_start` 召回记忆，`agent_end` 写入记忆
+- 🎯 **自动压缩**: 当消息数 > 50 时自动触发压缩
+- 📊 **详细日志**: 添加 lifecycle hooks 的详细日志
+
+### Implementation Details
+- `before_agent_start`: 调用 `lobster_assemble` 获取记忆，返回 `prependContext` 注入
+- `agent_end`: 调用 `lobster_ingest` 保存消息，自动检测并触发压缩
+- 配置选项：`lifecycleEnabled`（默认 true）
+
+### References
+- MemOS OpenClaw Plugin: https://github.com/MemTensor/MemOS-Cloud-OpenClaw-Plugin
+- Issue #183: https://github.com/SonicBotMan/lobster-press/issues/183
+
 ## [4.0.37] - 2026-03-22
 
 ### Fixed (E2E Test Bug Fixes - Issue #181)

--- a/index.ts
+++ b/index.ts
@@ -898,6 +898,127 @@ const lobsterPlugin = {
       `[lobster-press] Note: If you don't see "[lobster-press] afterTurn called" logs, ` +
       `your OpenClaw Gateway may not support ContextEngine.afterTurn hook`
     );
+    
+    // ── Lifecycle Hooks (v4.0.38: Issue #183 双模式插件) ───────────────────────
+    // 参考 MemOS OpenClaw Plugin：使用 lifecycle hooks 作为 ContextEngine 的降级方案
+    // 当 OpenClaw Gateway 不支持 ContextEngine.afterTurn 时，通过 lifecycle hooks 实现记忆管理
+    
+    // 1. before_agent_start: 召回记忆
+    api.on("before_agent_start", async (event: any, ctx: any) => {
+      // 检查是否启用 lifecycle 模式
+      const lifecycleEnabled = pluginConfig.lifecycleEnabled !== false;  // 默认 true
+      if (!lifecycleEnabled) return;
+      
+      // 获取 conversation_id
+      const conversationId = ctx?.sessionId || ctx?.sessionKey;
+      if (!conversationId) return;
+      
+      // 检查 prompt 是否存在
+      if (!event?.prompt || event.prompt.length < 3) return;
+      
+      try {
+        api.logger.info(`[lobster-press] Lifecycle: before_agent_start for session ${conversationId}`);
+        
+        // 调用 lobster_assemble 获取相关记忆
+        const result = await callMcp(pluginConfig, "lobster_assemble", {
+          conversation_id: conversationId,
+          token_budget: pluginConfig.maxContextTokens ?? 128000,
+        });
+        
+        // 解析返回结果
+        const text = result.content?.[0]?.text;
+        const data = text ? JSON.parse(text) : {};
+        const assembled = data?.assembled ?? [];
+        
+        if (assembled.length === 0) {
+          api.logger.info(`[lobster-press] Lifecycle: no memories found for session ${conversationId}`);
+          return;
+        }
+        
+        // 将记忆格式化为上下文
+        const memoryContext = assembled
+          .slice(-10)  // 最新 10 条记忆
+          .map((item: any) => `[${item.tier || 'memory'}]: ${item.content || ''}`)
+          .join('\n\n')
+          .slice(0, 8000);  // 限制 8000 字符
+        
+        if (!memoryContext) return;
+        
+        api.logger.info(`[lobster-press] Lifecycle: injected ${assembled.length} memories (${memoryContext.length} chars)`);
+        
+        // 返回 prependContext 注入记忆
+        return {
+          prependContext: `[LobsterPress Memory Context]\n${memoryContext}`,
+        };
+      } catch (error) {
+        api.logger.warn(`[lobster-press] Lifecycle: before_agent_start failed: ${error}`);
+      }
+    });
+    
+    // 2. agent_end: 写入记忆
+    api.on("agent_end", async (event: any, ctx: any) => {
+      // 检查是否启用 lifecycle 模式
+      const lifecycleEnabled = pluginConfig.lifecycleEnabled !== false;  // 默认 true
+      if (!lifecycleEnabled) return;
+      
+      // 检查是否成功
+      if (!event?.success || !event?.messages?.length) return;
+      
+      // 获取 conversation_id
+      const conversationId = ctx?.sessionId || ctx?.sessionKey;
+      if (!conversationId) return;
+      
+      try {
+        api.logger.info(`[lobster-press] Lifecycle: agent_end for session ${conversationId}`);
+        
+        // 提取最后一条对话（user + assistant）
+        const messages = event.messages.slice(-2).map((msg: any) => ({
+          id: msg.id || `msg-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+          role: msg.role || "user",
+          content: typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content || {}),
+          timestamp: msg.timestamp || new Date().toISOString(),
+        }));
+        
+        if (messages.length === 0) return;
+        
+        // 调用 lobster_ingest 保存消息
+        const result = await callMcp(pluginConfig, "lobster_ingest", {
+          conversation_id: conversationId,
+          messages: messages,
+        });
+        
+        // 解析返回结果
+        const responseText = result?.content?.[0]?.text;
+        const response = responseText ? JSON.parse(responseText) : {};
+        
+        if (response.ingested > 0) {
+          api.logger.info(`[lobster-press] Lifecycle: ingested ${response.ingested} messages for session ${conversationId}`);
+          
+          // 检查是否需要压缩（消息数 > 50）
+          const describeResult = await callMcp(pluginConfig, "lobster_describe", {
+            conversation_id: conversationId,
+          });
+          
+          const describeText = describeResult.content?.[0]?.text;
+          const stats = describeText ? JSON.parse(describeText) : {};
+          const messageCount = stats?.message_count ?? 0;
+          
+          if (messageCount > 50) {
+            api.logger.info(`[lobster-press] Lifecycle: triggering compress for session ${conversationId} (${messageCount} messages)`);
+            
+            // 调用 lobster_compress 压缩记忆
+            await callMcp(pluginConfig, "lobster_compress", {
+              conversation_id: conversationId,
+              force: false,
+            });
+          }
+        }
+      } catch (error) {
+        api.logger.warn(`[lobster-press] Lifecycle: agent_end failed: ${error}`);
+      }
+    });
+    
+    api.logger.info(`[lobster-press] Lifecycle hooks registered (before_agent_start + agent_end)`);
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sonicbotman/lobster-press",
-  "version": "4.0.36",
+  "version": "4.0.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sonicbotman/lobster-press",
-      "version": "4.0.36",
+      "version": "4.0.38",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.34.48"
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.0",
         "openclaw": "^2026.3.0",
-        "typescript": "^5.4.0",
+        "typescript": "^5.9.3",
         "vitest": "^4.1.0"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sonicbotman/lobster-press",
-  "version": "4.0.37",
-  "description": "Cognitive Memory System for AI Agents \u2014 OpenClaw Plugin",
+  "version": "4.0.38",
+  "description": "Cognitive Memory System for AI Agents — OpenClaw Plugin",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@vitest/coverage-v8": "^4.1.0",
     "openclaw": "^2026.3.0",
-    "typescript": "^5.4.0",
+    "typescript": "^5.9.3",
     "vitest": "^4.1.0"
   },
   "repository": {

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -6,7 +6,7 @@ LobsterPress - Cognitive Memory System for AI Agents
 所有其他文件应从此处导入版本号。
 """
 
-__version__ = "4.0.37"
+__version__ = "4.0.38"
 __author__ = "SonicBotMan"
 __email__ = "sonicbotman@example.com"
 


### PR DESCRIPTION
**已修复并发布 v4.0.40**

## 修复内容
- MCP server cwd 路径：`cwd: join(__dirname, "..")` (index.ts line 149)
- Lifecycle hooks 恢复：before_agent_start + agent_end

## 验证结果
- ✅ MCP server 启动成功
- ✅ Lifecycle hooks 注册成功
- ✅ 测试机验证通过

## 发布
- npm: @sonicbotman/lobster-press@4.0.40
- GitHub: https://github.com/SonicBotMan/lobster-press/releases/tag/v4.0.40