### PR TITLE
fix: src/__init__.py 语法错误（v4.0.40 CI 失败）

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -8,23 +8,16 @@ LobsterPress - Cognitive Memory System for AI Agents
 
 
 __version__ = "4.0.40"
-
-__version__ = "4.0.40"
- (v4.0.40: 修复 MCP cwd 路径 + 恢复 lifecycle hooks)
 __author__ = "SonicBotMan"
 __email__ = "sonicbotman@example.com"
 
 # 版本历史（最近5个）
 VERSION_HISTORY = [
-
+    ("4.0.40", "2026-03-22", "Issue #184 - MCP cwd path fix + lifecycle hooks"),
     ("4.0.37", "2026-03-22", "Issue #181 - E2E test bug fixes"),
     ("4.0.36", "2026-03-22", "Issue #174 - Expert feedback optimization"),
-
-    ("4.0.40", "2026-03-22", "Issue #174 - Expert feedback optimization"),
- (v4.0.40: 修复 MCP cwd 路径 + 恢复 lifecycle hooks)
     ("4.0.35", "2026-03-22", "Issue #174 - P0/P1/P2 fixes"),
     ("4.0.34", "2026-03-21", "Issue #173 - TF-IDF optimization"),
-    ("4.0.33", "2026-03-21", "Issue #172 - Performance improvements"),
 ]
 
 def get_version():


### PR DESCRIPTION
## 问题
v4.0.40 的 CI 失败：
- `src/__init__.py` 有 IndentationError
- 原因：rebase 冲突解决时文件被破坏

## 修复
- 删除重复的 `__version__` 行
- 删除重复的 VERSION_HISTORY 条目
- 清理错误的注释行

## 验证
```bash
python3 -c "import src; print(src.__version__)"
# 输出: 4.0.40
```

## CI 失败链接
https://github.com/SonicBotMan/lobster-press/actions/runs/23408193476

Fixes CI failure in v4.0.40