### PR TITLE
fix: P1 code quality — dedup cosine/token, secure viewer

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -19,6 +19,8 @@ from typing import List, Dict, Optional, Any
 from pathlib import Path
 from datetime import datetime
 
+from src.utils.tokens import estimate_tokens as _estimate_tokens_shared
+
 logger = logging.getLogger(__name__)
 # v4.0.0: 导入 ThreePassTrimmer（兼容多种导入场景）
 try:
@@ -1893,21 +1895,8 @@ class LobsterDatabase:
         return str(content)
 
     def _estimate_tokens(self, text: str) -> int:
-        """估算 token 数量
-
-        Args:
-            text: 文本内容
-
-        Returns:
-            token 数量
-        """
-        # 简单估算：英文 4 字符 = 1 token，中文 1.5 字符 = 1 token
-        char_count = len(text)
-        chinese_chars = sum(1 for c in text if "\u4e00" <= c <= "\u9fff")
-        english_chars = char_count - chinese_chars
-
-        tokens = (english_chars / 4) + (chinese_chars / 1.5)
-        return int(tokens)
+        """估算 token 数量。委托给 utils.tokens.estimate_tokens。"""
+        return _estimate_tokens_shared(text)
 
     def _execute_fetch_all(
         self, sql: str, params: tuple = (), table: str = None

--- a/src/pipeline/event_segmenter.py
+++ b/src/pipeline/event_segmenter.py
@@ -19,6 +19,9 @@ from typing import List, Dict, Optional
 from datetime import datetime
 from collections import Counter
 
+from src.utils.math import cosine_similarity
+from src.utils.tokens import estimate_tokens
+
 logger = logging.getLogger(__name__)
 
 class EventSegmenter:
@@ -179,23 +182,12 @@ class EventSegmenter:
         return Counter(words)
 
     def _cosine_similarity(self, a: Counter, b: Counter) -> float:
-        """计算两个词频向量的余弦相似度"""
-        if not a or not b:
-            return 0.0
-
-        common = set(a.keys()) & set(b.keys())
-        dot = sum(a[w] * b[w] for w in common)
-        norm_a = math.sqrt(sum(v**2 for v in a.values()))
-        norm_b = math.sqrt(sum(v**2 for v in b.values()))
-
-        if norm_a == 0 or norm_b == 0:
-            return 0.0
-        return dot / (norm_a * norm_b)
+        """计算两个词频向量的余弦相似度。委托给 utils.math。"""
+        return cosine_similarity(a, b)
 
     def _estimate_tokens(self, text: str) -> int:
-        """粗估 token 数（与 database.py 保持一致）"""
-        chinese = sum(1 for c in text if "\u4e00" <= c <= "\u9fff")
-        return int((len(text) - chinese) / 4 + chinese / 1.5)
+        """粗估 token 数。委托给 utils.tokens。"""
+        return estimate_tokens(text)
 
 
 # ==================== 单元测试 ====================

--- a/src/pipeline/semantic_dedup.py
+++ b/src/pipeline/semantic_dedup.py
@@ -17,6 +17,8 @@ import logging
 from typing import List, Tuple, Set
 from collections import Counter
 
+from src.utils.math import cosine_similarity
+
 logger = logging.getLogger(__name__)
 try:
     from .tfidf_scorer import ScoredMessage
@@ -123,32 +125,8 @@ class SemanticDeduplicator:
         return tokens
     
     def _cosine(self, a: List[str], b: List[str]) -> float:
-        """计算余弦相似度（基于 TF 向量）
-        
-        Args:
-            a: 消息 A 的 token 列表
-            b: 消息 B 的 token 列表
-        
-        Returns:
-            相似度（0-1）
-        """
-        if not a or not b:
-            return 0.0
-        
-        tf_a = Counter(a)
-        tf_b = Counter(b)
-        
-        all_terms = set(tf_a) | set(tf_b)
-        
-        dot_product = sum(tf_a.get(t, 0) * tf_b.get(t, 0) for t in all_terms)
-        
-        norm_a = math.sqrt(sum(v ** 2 for v in tf_a.values()))
-        norm_b = math.sqrt(sum(v ** 2 for v in tf_b.values()))
-        
-        if norm_a == 0 or norm_b == 0:
-            return 0.0
-        
-        return dot_product / (norm_a * norm_b)
+        """计算余弦相似度。委托给 utils.math.cosine_similarity。"""
+        return cosine_similarity(a, b)
 
 
 # ==================== 测试代码 ====================

--- a/src/pipeline/tfidf_scorer.py
+++ b/src/pipeline/tfidf_scorer.py
@@ -24,6 +24,8 @@ logger = logging.getLogger(__name__)
 from typing import List, Dict, Union
 from dataclasses import dataclass
 
+from src.utils.math import cosine_similarity
+
 
 # 压缩豁免的消息类型（这些类型的消息不应被 DAG 折叠）
 EXEMPT_TYPES = {"decision", "config", "code", "error"}
@@ -178,35 +180,9 @@ class TFIDFScorer:
         return idf
     
     def _cosine_similarity(self, tokens1: List[str], tokens2: List[str]) -> float:
-        """计算两组 token 的余弦相似度（缺陷 2 修复）
-        
-        Args:
-            tokens1: 第一组 token
-            tokens2: 第二组 token
-        
-        Returns:
-            余弦相似度（0.0 - 1.0）
-        """
-        if not tokens1 or not tokens2:
-            return 0.0
-        
-        # 构建 TF 向量
-        tf1 = Counter(tokens1)
-        tf2 = Counter(tokens2)
-        
-        # 找到所有词
-        all_terms = set(tf1.keys()) | set(tf2.keys())
-        
-        # 计算点积和模长
-        dot_product = sum(tf1.get(term, 0) * tf2.get(term, 0) for term in all_terms)
-        norm1 = math.sqrt(sum(v ** 2 for v in tf1.values()))
-        norm2 = math.sqrt(sum(v ** 2 for v in tf2.values()))
-        
-        if norm1 == 0 or norm2 == 0:
-            return 0.0
-        
-        return dot_product / (norm1 * norm2)
-    
+        """计算两组 token 的余弦相似度。委托给 utils.math.cosine_similarity。"""
+        return cosine_similarity(tokens1, tokens2)
+
     def score_and_tag(self, messages: List[Dict]) -> List[ScoredMessage]:
         """批量评分并打标签（v2.5.0 核心接口）
 

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -12,6 +12,8 @@ Version: v4.0.41
 import logging
 from typing import List, Dict
 
+from src.utils.tokens import estimate_tokens
+
 logger = logging.getLogger(__name__)
 
 # ==================== 叶子摘要 Prompt ====================
@@ -213,18 +215,6 @@ def build_conflict_detection_prompt(statement1: str, statement2: str) -> str:
 
 
 # ==================== Prompt 优化工具 ====================
-
-def estimate_tokens(text: str) -> int:
-    """估算文本的 token 数（粗略估计：1 token ≈ 4 字符）
-    
-    Args:
-        text: 文本
-    
-    Returns:
-        估算的 token 数
-    """
-    return len(text) // 4
-
 
 def truncate_messages(messages: List[Dict], max_tokens: int = 20000) -> List[Dict]:
     """截断消息列表以适应 token 限制

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""LobsterPress utility functions."""

--- a/src/utils/math.py
+++ b/src/utils/math.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""
+Shared mathematical utility functions.
+
+Eliminates duplicate cosine similarity implementations across modules.
+"""
+
+import math
+from collections import Counter
+from typing import List, Union
+
+
+def cosine_similarity(
+    a: Union[List[str], Counter],
+    b: Union[List[str], Counter],
+) -> float:
+    """Compute cosine similarity between two token vectors.
+
+    Accepts either raw token lists (converted to TF Counter internally)
+    or pre-computed Counter objects.
+
+    Args:
+        a: Token list or Counter for vector A.
+        b: Token list or Counter for vector B.
+
+    Returns:
+        Cosine similarity in [0.0, 1.0].
+    """
+    if not a or not b:
+        return 0.0
+
+    tf_a = Counter(a) if isinstance(a, list) else a
+    tf_b = Counter(b) if isinstance(b, list) else b
+
+    all_terms = set(tf_a.keys()) | set(tf_b.keys())
+    dot_product = sum(tf_a.get(t, 0) * tf_b.get(t, 0) for t in all_terms)
+
+    norm_a = math.sqrt(sum(v ** 2 for v in tf_a.values()))
+    norm_b = math.sqrt(sum(v ** 2 for v in tf_b.values()))
+
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+
+    return dot_product / (norm_a * norm_b)

--- a/src/utils/tokens.py
+++ b/src/utils/tokens.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+"""
+Shared token estimation functions.
+
+Eliminates duplicate token estimation implementations across modules.
+English: ~4 chars per token. Chinese: ~1.5 chars per token.
+"""
+
+
+def estimate_tokens(text: str) -> int:
+    """Estimate token count for mixed Chinese/English text.
+
+    Uses the same formula as tiktoken's rough approximation:
+    - English: 4 characters ≈ 1 token
+    - Chinese: 1.5 characters ≈ 1 token
+
+    Args:
+        text: Input text.
+
+    Returns:
+        Estimated token count.
+    """
+    if not text:
+        return 0
+    chinese = sum(1 for c in text if "\u4e00" <= c <= "\u9fff")
+    english = len(text) - chinese
+    return int(english / 4 + chinese / 1.5)

--- a/src/viewer/server.py
+++ b/src/viewer/server.py
@@ -101,7 +101,7 @@ class ViewerHandler(BaseHTTPRequestHandler):
         """发送 JSON 响应"""
         self.send_response(status)
         self.send_header("Content-Type", "application/json")
-        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Origin", "http://127.0.0.1:* http://localhost:*")
         self.end_headers()
         self.wfile.write(json.dumps(data, ensure_ascii=False).encode())
 
@@ -241,9 +241,23 @@ class ViewerHandler(BaseHTTPRequestHandler):
         )
 
     def _api_login(self):
-        """登录 API"""
-        params = parse_qs(urlparse(self.path).query)
-        password = params.get("password", [""])[0]
+        """登录 API — accepts POST with JSON body for password."""
+        try:
+            content_length = int(self.headers.get("Content-Length", 0))
+        except (ValueError, TypeError):
+            content_length = 0
+        body = self.rfile.read(content_length).decode("utf-8") if content_length else ""
+        password = ""
+        if body:
+            try:
+                data = json.loads(body)
+                password = data.get("password", "")
+            except (json.JSONDecodeError, ValueError):
+                pass
+        # Fallback: try query string (backward compatibility with GET login)
+        if not password:
+            params = parse_qs(urlparse(self.path).query)
+            password = params.get("password", [""])[0]
 
         if (
             self._password_hash


### PR DESCRIPTION
## 修复内容

### P1-8: cosine_similarity 去重
- 提取 `src/utils/math.py` 统一实现
- 4 处重复代码（tfidf_scorer, semantic_dedup, event_segmenter ×2）→ 委托调用
- 支持 List[str] 和 Counter 两种输入

### P1-9: estimate_tokens 去重
- 提取 `src/utils/tokens.py` 统一实现
- 3 处重复代码（database, event_segmenter, prompts）→ 委托调用
- prompts.py 原来用 `len(text)//4`（不区分中文），现在统一为精确的中英文混合公式

### P1-13: Viewer 登录支持 POST
- 优先读 POST JSON body 中的 password
- 保留 GET query string fallback（向后兼容）
- 处理 Content-Length 缺失/无效

### P1-14: Viewer CORS 限制
- `Access-Control-Allow-Origin: *` → 仅允许 localhost

## 验证
- 481 passed, 0 failed

## 备注
- CI lint 的 `continue-on-error` 修改因 OAuth scope 限制无法通过 PR 推送 workflow 文件，需手动在 GitHub 上修改