### PR TITLE
fix: P1-10 LLM provider dedup + P1-7 sys.path cleanup

### DIFF
--- a/src/agent_tools.py
+++ b/src/agent_tools.py
@@ -8,18 +8,15 @@ Author: LobsterPress Team
 Version: v4.0.41
 """
 
-import sys
 import json
 import argparse
 import logging
 from typing import List, Dict, Optional
-from pathlib import Path
+
 
 logger = logging.getLogger(__name__)
-# 添加 database 模块
-sys.path.insert(0, str(Path(__file__).parent))
-from database import LobsterDatabase
-from pipeline.tfidf_scorer import TFIDFScorer
+from src.database import LobsterDatabase
+from src.pipeline.tfidf_scorer import TFIDFScorer
 
 
 # ==================== lobster_grep ====================

--- a/src/dag_compressor.py
+++ b/src/dag_compressor.py
@@ -8,19 +8,16 @@ Author: LobsterPress Team
 Version: v4.0.41
 """
 
-import sys
 import json
 import logging
 from typing import List, Dict, Optional, Tuple
 from datetime import datetime
-from pathlib import Path
+
 
 logger = logging.getLogger(__name__)
-# 添加 database 模块
-sys.path.insert(0, str(Path(__file__).parent))
-from database import LobsterDatabase
-from pipeline.event_segmenter import EventSegmenter
-from prompts import build_leaf_summary_prompt, build_condensed_summary_prompt
+from src.database import LobsterDatabase
+from src.pipeline.event_segmenter import EventSegmenter
+from src.prompts import build_leaf_summary_prompt, build_condensed_summary_prompt
 
 
 class DAGCompressor:

--- a/src/incremental_compressor.py
+++ b/src/incremental_compressor.py
@@ -8,24 +8,20 @@ Author: LobsterPress Team
 Version: v4.0.41
 """
 
-import sys
 import logging
-from pathlib import Path
 from typing import Dict, Optional
 from datetime import datetime
 
 logger = logging.getLogger(__name__)
-# 添加 database 模块
-sys.path.insert(0, str(Path(__file__).parent))
-from database import LobsterDatabase
-from dag_compressor import DAGCompressor
-from pipeline.tfidf_scorer import TFIDFScorer, EXEMPT_TYPES
-from pipeline.semantic_dedup import SemanticDeduplicator
+from src.database import LobsterDatabase
+from src.dag_compressor import DAGCompressor
+from src.pipeline.tfidf_scorer import TFIDFScorer, EXEMPT_TYPES
+from src.pipeline.semantic_dedup import SemanticDeduplicator
 
 # v3.0.0: 语义记忆和矛盾检测
 try:
-    from semantic_memory import SemanticMemory
-    from pipeline.conflict_detector import ConflictDetector
+    from src.semantic_memory import SemanticMemory
+    from src.pipeline.conflict_detector import ConflictDetector
     SEMANTIC_MEMORY_AVAILABLE = True
 except ImportError:
     SEMANTIC_MEMORY_AVAILABLE = False

--- a/src/llm_providers.py
+++ b/src/llm_providers.py
@@ -8,79 +8,102 @@ LobsterPress LLM Providers - 各 LLM 提供商适配器
 - 国内：DeepSeek, 智谱 GLM, 百度文心, 阿里通义千问
 
 Author: LobsterPress Team
-Version: v4.0.41
+Version: v5.0.0
 """
 
 import os
+import logging
 from typing import Optional, Dict, Any
+
 from src.llm_client import BaseLLMClient
 
+logger = logging.getLogger(__name__)
 
-# ==================== 国际提供商 ====================
 
-class OpenAIClient(BaseLLMClient):
-    """OpenAI GPT 系列"""
-    
+# ==================== OpenAI-compatible 基类 ====================
+
+class OpenAICompatibleClient(BaseLLMClient):
+    """OpenAI-compatible API 客户端基类。
+
+    覆盖所有使用 OpenAI SDK chat.completions.create 接口的提供商。
+    子类只需定义 base_url / env_key / default_model。
+    """
+
+    base_url: Optional[str] = None
+    env_key: str = ""           # 环境变量名，如 'DEEPSEEK_API_KEY'
+    default_model: str = ""
+
     def __init__(
         self,
         api_key: Optional[str] = None,
-        model: str = "gpt-4o-mini",
+        model: Optional[str] = None,
         base_url: Optional[str] = None,
-        **kwargs
+        **kwargs,
     ):
-        self.api_key = api_key or os.getenv('OPENAI_API_KEY')
-        self.model = model
-        self.base_url = base_url or os.getenv('OPENAI_BASE_URL')
+        self.api_key = api_key or os.getenv(self.env_key)
+        self.model = model or self.default_model
+        self.base_url = base_url or self.__class__.base_url
         self.kwargs = kwargs
         self._client = None
-    
+
     def _get_client(self):
-        """延迟加载 OpenAI 客户端"""
+        """延迟加载 OpenAI 客户端。"""
         if self._client is None:
             try:
                 from openai import OpenAI
-                self._client = OpenAI(
-                    api_key=self.api_key,
-                    base_url=self.base_url
-                )
+                kwargs = {"api_key": self.api_key}
+                if self.base_url:
+                    kwargs["base_url"] = self.base_url
+                self._client = OpenAI(**kwargs)
             except ImportError:
                 raise ImportError("请安装 openai: pip install openai")
         return self._client
-    
+
     def generate(self, prompt: str, **kwargs) -> str:
         client = self._get_client()
-        
-        # 合并参数
+
         params = {
-            'model': self.model,
-            'messages': [{'role': 'user', 'content': prompt}],
-            'temperature': kwargs.get('temperature', self.kwargs.get('temperature', 0.7)),
-            'max_tokens': kwargs.get('max_tokens', self.kwargs.get('max_tokens', 500))
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": kwargs.get(
+                "temperature", self.kwargs.get("temperature", 0.7)
+            ),
+            "max_tokens": kwargs.get(
+                "max_tokens", self.kwargs.get("max_tokens", 500)
+            ),
         }
-        
+
         response = client.chat.completions.create(**params)
         return response.choices[0].message.content
-    
+
     def is_available(self) -> bool:
         return self.api_key is not None
 
 
+# ==================== 国际提供商 ====================
+
+class OpenAIClient(OpenAICompatibleClient):
+    """OpenAI GPT 系列"""
+    base_url = None  # 使用 SDK 默认值
+    env_key = "OPENAI_API_KEY"
+    default_model = "gpt-4o-mini"
+
+
 class AnthropicClient(BaseLLMClient):
     """Anthropic Claude 系列"""
-    
+
     def __init__(
         self,
         api_key: Optional[str] = None,
         model: str = "claude-3-5-sonnet-20241022",
-        **kwargs
+        **kwargs,
     ):
-        self.api_key = api_key or os.getenv('ANTHROPIC_API_KEY')
+        self.api_key = api_key or os.getenv("ANTHROPIC_API_KEY")
         self.model = model
         self.kwargs = kwargs
         self._client = None
-    
+
     def _get_client(self):
-        """延迟加载 Anthropic 客户端"""
         if self._client is None:
             try:
                 from anthropic import Anthropic
@@ -88,298 +111,156 @@ class AnthropicClient(BaseLLMClient):
             except ImportError:
                 raise ImportError("请安装 anthropic: pip install anthropic")
         return self._client
-    
+
     def generate(self, prompt: str, **kwargs) -> str:
         client = self._get_client()
-        
-        # 合并参数
         params = {
-            'model': self.model,
-            'max_tokens': kwargs.get('max_tokens', self.kwargs.get('max_tokens', 500)),
-            'messages': [{'role': 'user', 'content': prompt}]
+            "model": self.model,
+            "max_tokens": kwargs.get(
+                "max_tokens", self.kwargs.get("max_tokens", 500)
+            ),
+            "messages": [{"role": "user", "content": prompt}],
         }
-        
         response = client.messages.create(**params)
         return response.content[0].text
-    
+
     def is_available(self) -> bool:
         return self.api_key is not None
 
 
 class GeminiClient(BaseLLMClient):
     """Google Gemini 系列"""
-    
+
     def __init__(
         self,
         api_key: Optional[str] = None,
         model: str = "gemini-pro",
-        **kwargs
+        **kwargs,
     ):
-        self.api_key = api_key or os.getenv('GOOGLE_API_KEY')
+        self.api_key = api_key or os.getenv("GOOGLE_API_KEY")
         self.model = model
         self.kwargs = kwargs
         self._client = None
-    
+
     def _get_client(self):
-        """延迟加载 Gemini 客户端"""
         if self._client is None:
             try:
                 import google.generativeai as genai
                 genai.configure(api_key=self.api_key)
                 self._client = genai.GenerativeModel(self.model)
             except ImportError:
-                raise ImportError("请安装 google-generativeai: pip install google-generativeai")
+                raise ImportError(
+                    "请安装 google-generativeai: pip install google-generativeai"
+                )
         return self._client
-    
+
     def generate(self, prompt: str, **kwargs) -> str:
         client = self._get_client()
-        
-        # 合并参数
         generation_config = {
-            'temperature': kwargs.get('temperature', self.kwargs.get('temperature', 0.7)),
-            'max_output_tokens': kwargs.get('max_tokens', self.kwargs.get('max_tokens', 500))
+            "temperature": kwargs.get(
+                "temperature", self.kwargs.get("temperature", 0.7)
+            ),
+            "max_output_tokens": kwargs.get(
+                "max_tokens", self.kwargs.get("max_tokens", 500)
+            ),
         }
-        
-        response = client.generate_content(prompt, generation_config=generation_config)
+        response = client.generate_content(
+            prompt, generation_config=generation_config
+        )
         return response.text
-    
+
     def is_available(self) -> bool:
         return self.api_key is not None
 
 
-class MistralClient(BaseLLMClient):
+class MistralClient(OpenAICompatibleClient):
     """Mistral AI"""
-    
-    def __init__(
-        self,
-        api_key: Optional[str] = None,
-        model: str = "mistral-small-latest",
-        **kwargs
-    ):
-        self.api_key = api_key or os.getenv('MISTRAL_API_KEY')
-        self.model = model
-        self.kwargs = kwargs
-        self._client = None
-    
-    def _get_client(self):
-        """延迟加载 Mistral 客户端"""
-        if self._client is None:
-            try:
-                from mistralai import Mistral
-                self._client = Mistral(api_key=self.api_key)
-            except ImportError:
-                raise ImportError("请安装 mistralai: pip install mistralai")
-        return self._client
-    
-    def generate(self, prompt: str, **kwargs) -> str:
-        client = self._get_client()
-        
-        # 合并参数
-        params = {
-            'model': self.model,
-            'messages': [{'role': 'user', 'content': prompt}],
-            'temperature': kwargs.get('temperature', self.kwargs.get('temperature', 0.7)),
-            'max_tokens': kwargs.get('max_tokens', self.kwargs.get('max_tokens', 500))
-        }
-        
-        response = client.chat.complete(**params)
-        return response.choices[0].message.content
-    
-    def is_available(self) -> bool:
-        return self.api_key is not None
+    base_url = None
+    env_key = "MISTRAL_API_KEY"
+    default_model = "mistral-small-latest"
 
 
 # ==================== 国内提供商 ====================
 
-class DeepSeekClient(BaseLLMClient):
+class DeepSeekClient(OpenAICompatibleClient):
     """DeepSeek"""
-    
-    def __init__(
-        self,
-        api_key: Optional[str] = None,
-        model: str = "deepseek-chat",
-        **kwargs
-    ):
-        self.api_key = api_key or os.getenv('DEEPSEEK_API_KEY')
-        self.model = model
-        self.kwargs = kwargs
-        self._client = None
-    
-    def _get_client(self):
-        """延迟加载 DeepSeek 客户端（使用 OpenAI 兼容接口）"""
-        if self._client is None:
-            try:
-                from openai import OpenAI
-                self._client = OpenAI(
-                    api_key=self.api_key,
-                    base_url="https://api.deepseek.com"
-                )
-            except ImportError:
-                raise ImportError("请安装 openai: pip install openai")
-        return self._client
-    
-    def generate(self, prompt: str, **kwargs) -> str:
-        client = self._get_client()
-        
-        # 合并参数
-        params = {
-            'model': self.model,
-            'messages': [{'role': 'user', 'content': prompt}],
-            'temperature': kwargs.get('temperature', self.kwargs.get('temperature', 0.7)),
-            'max_tokens': kwargs.get('max_tokens', self.kwargs.get('max_tokens', 500))
-        }
-        
-        response = client.chat.completions.create(**params)
-        return response.choices[0].message.content
-    
-    def is_available(self) -> bool:
-        return self.api_key is not None
+    base_url = "https://api.deepseek.com"
+    env_key = "DEEPSEEK_API_KEY"
+    default_model = "deepseek-chat"
 
 
-class ZhipuClient(BaseLLMClient):
+class ZhipuClient(OpenAICompatibleClient):
     """智谱 GLM 系列"""
-    
-    def __init__(
-        self,
-        api_key: Optional[str] = None,
-        model: str = "glm-4-flash",
-        **kwargs
-    ):
-        self.api_key = api_key or os.getenv('ZHIPU_API_KEY')
-        self.model = model
-        self.kwargs = kwargs
-        self._client = None
-    
-    def _get_client(self):
-        """延迟加载智谱客户端"""
-        if self._client is None:
-            try:
-                from zhipuai import ZhipuAI
-                self._client = ZhipuAI(api_key=self.api_key)
-            except ImportError:
-                raise ImportError("请安装 zhipuai: pip install zhipuai")
-        return self._client
-    
-    def generate(self, prompt: str, **kwargs) -> str:
-        client = self._get_client()
-        
-        # 合并参数
-        params = {
-            'model': self.model,
-            'messages': [{'role': 'user', 'content': prompt}],
-            'temperature': kwargs.get('temperature', self.kwargs.get('temperature', 0.7)),
-            'max_tokens': kwargs.get('max_tokens', self.kwargs.get('max_tokens', 500))
-        }
-        
-        response = client.chat.completions.create(**params)
-        return response.choices[0].message.content
-    
-    def is_available(self) -> bool:
-        return self.api_key is not None
+    base_url = "https://open.bigmodel.cn/api/paas/v4"
+    env_key = "ZHIPU_API_KEY"
+    default_model = "glm-4-flash"
 
 
 class BaiduClient(BaseLLMClient):
     """百度文心系列"""
-    
+
     def __init__(
         self,
         api_key: Optional[str] = None,
         secret_key: Optional[str] = None,
         model: str = "ernie-speed-8k",
-        **kwargs
+        **kwargs,
     ):
-        self.api_key = api_key or os.getenv('BAIDU_API_KEY')
-        self.secret_key = secret_key or os.getenv('BAIDU_SECRET_KEY')
+        self.api_key = api_key or os.getenv("BAIDU_API_KEY")
+        self.secret_key = secret_key or os.getenv("BAIDU_SECRET_KEY")
         self.model = model
         self.kwargs = kwargs
         self._access_token = None
-    
+
     def _get_access_token(self):
-        """获取百度 access_token"""
         if self._access_token is None:
             import urllib.request
-            import urllib.parse
-            import json
-            
-            url = f"https://aip.baidubce.com/oauth/2.0/token?grant_type=client_credentials&client_id={self.api_key}&client_secret={self.secret_key}"
-            
+            import json as _json
+
+            url = (
+                "https://aip.baidubce.com/oauth/2.0/token"
+                f"?grant_type=client_credentials&client_id={self.api_key}"
+                f"&client_secret={self.secret_key}"
+            )
             req = urllib.request.Request(url)
             with urllib.request.urlopen(req) as response:
-                result = json.loads(response.read().decode('utf-8'))
-                self._access_token = result['access_token']
-        
+                result = _json.loads(response.read().decode("utf-8"))
+                self._access_token = result["access_token"]
         return self._access_token
-    
+
     def generate(self, prompt: str, **kwargs) -> str:
         import urllib.request
-        import json
-        
+        import json as _json
+
         access_token = self._get_access_token()
-        url = f"https://aip.baidubce.com/rpc/2.0/ai_custom/v1/wenxinworkshop/chat/{self.model}?access_token={access_token}"
-        
-        # 合并参数
+        url = (
+            "https://aip.baidubce.com/rpc/2.0/ai_custom/v1/wenxinworkshop/chat"
+            f"/{self.model}?access_token={access_token}"
+        )
         data = {
-            'messages': [{'role': 'user', 'content': prompt}],
-            'temperature': kwargs.get('temperature', self.kwargs.get('temperature', 0.7))
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": kwargs.get(
+                "temperature", self.kwargs.get("temperature", 0.7)
+            ),
         }
-        
         req = urllib.request.Request(
             url,
-            data=json.dumps(data).encode('utf-8'),
-            headers={'Content-Type': 'application/json'}
+            data=_json.dumps(data).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
         )
-        
         with urllib.request.urlopen(req) as response:
-            result = json.loads(response.read().decode('utf-8'))
-            return result['result']
-    
+            result = _json.loads(response.read().decode("utf-8"))
+            return result["result"]
+
     def is_available(self) -> bool:
         return self.api_key is not None and self.secret_key is not None
 
 
-class AlibabaClient(BaseLLMClient):
+class AlibabaClient(OpenAICompatibleClient):
     """阿里通义千问系列"""
-    
-    def __init__(
-        self,
-        api_key: Optional[str] = None,
-        model: str = "qwen-turbo",
-        **kwargs
-    ):
-        self.api_key = api_key or os.getenv('ALIBABA_API_KEY')
-        self.model = model
-        self.kwargs = kwargs
-        self._client = None
-    
-    def _get_client(self):
-        """延迟加载通义千问客户端（使用 OpenAI 兼容接口）"""
-        if self._client is None:
-            try:
-                from openai import OpenAI
-                self._client = OpenAI(
-                    api_key=self.api_key,
-                    base_url="https://dashscope.aliyuncs.com/compatible-mode/v1"
-                )
-            except ImportError:
-                raise ImportError("请安装 openai: pip install openai")
-        return self._client
-    
-    def generate(self, prompt: str, **kwargs) -> str:
-        client = self._get_client()
-        
-        # 合并参数
-        params = {
-            'model': self.model,
-            'messages': [{'role': 'user', 'content': prompt}],
-            'temperature': kwargs.get('temperature', self.kwargs.get('temperature', 0.7)),
-            'max_tokens': kwargs.get('max_tokens', self.kwargs.get('max_tokens', 500))
-        }
-        
-        response = client.chat.completions.create(**params)
-        return response.choices[0].message.content
-    
-    def is_available(self) -> bool:
-        return self.api_key is not None
+    base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+    env_key = "ALIBABA_API_KEY"
+    default_model = "qwen-turbo"
 
 
 # ==================== 工厂函数 ====================
@@ -388,35 +269,35 @@ def get_provider_client(
     provider: str,
     api_key: Optional[str] = None,
     model: Optional[str] = None,
-    **kwargs
+    **kwargs,
 ) -> BaseLLMClient:
     """获取提供商客户端（工厂函数）
-    
+
     Args:
         provider: 提供商名称
         api_key: API 密钥
         model: 模型名称
         **kwargs: 额外参数
-    
+
     Returns:
         LLM 客户端实例
     """
-    # 提供商映射
     providers = {
-        'openai': OpenAIClient,
-        'anthropic': AnthropicClient,
-        'gemini': GeminiClient,
-        'mistral': MistralClient,
-        'deepseek': DeepSeekClient,
-        'zhipu': ZhipuClient,
-        'baidu': BaiduClient,
-        'alibaba': AlibabaClient
+        "openai": OpenAIClient,
+        "anthropic": AnthropicClient,
+        "gemini": GeminiClient,
+        "mistral": MistralClient,
+        "deepseek": DeepSeekClient,
+        "zhipu": ZhipuClient,
+        "baidu": BaiduClient,
+        "alibaba": AlibabaClient,
     }
-    
-    # 获取提供商类
+
     provider_class = providers.get(provider.lower())
     if provider_class is None:
-        raise ValueError(f"不支持的 LLM 提供商: {provider}。支持的提供商: {list(providers.keys())}")
-    
-    # 创建客户端
+        raise ValueError(
+            f"不支持的 LLM 提供商: {provider}。"
+            f"支持的提供商: {list(providers.keys())}"
+        )
+
     return provider_class(api_key=api_key, model=model, **kwargs)

--- a/src/pipeline/batch_importer.py
+++ b/src/pipeline/batch_importer.py
@@ -21,16 +21,12 @@ import os
 import json
 import csv
 import logging
-from pathlib import Path
 from datetime import datetime
 from typing import List, Dict, Optional, Iterator
 
 logger = logging.getLogger(__name__)
-# 添加 src 模块
-sys.path.insert(0, str(Path(__file__).parent.parent))
-
-from database import LobsterDatabase
-from pipeline.tfidf_scorer import TFIDFScorer, ScoredMessage
+from src.database import LobsterDatabase
+from src.pipeline.tfidf_scorer import TFIDFScorer, ScoredMessage
 
 
 class BatchImporter:


### PR DESCRIPTION
## P1-10: LLM Provider 去重

提取 `OpenAICompatibleClient` 基类，覆盖 5 个使用 OpenAI SDK 的 provider：
- OpenAI / DeepSeek / Zhipu / Alibaba / Mistral → 共享基类
- 子类只需声明 `base_url`/`env_key`/`default_model`
- Anthropic / Gemini / Baidu 保持独立（不同 SDK）
- **422 行 → 290 行（-31%）**

## P1-7: sys.path 污染清理

移除 4 个文件中的 `sys.path.insert(0, ...)`：
- dag_compressor, agent_tools, incremental_compressor, batch_importer
- 裸导入改为标准 `from src.xxx import ...`
- 清理不再需要的 `import sys`/`from pathlib import Path`

## 验证
- 481 passed, 0 failed