### PR TITLE
ci: remove continue-on-error gates in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,15 +67,12 @@ jobs:
           echo "NPM version: $(npm --version)"
           echo "Installing dependencies..."
           npm install --verbose 2>&1 | head -100 || npm install
-        continue-on-error: false
 
       - name: Build TypeScript
         run: npm run build
-        continue-on-error: true
 
       - name: Run Node.js tests
         run: npm test
-        continue-on-error: true
 
   lint:
     runs-on: ubuntu-latest
@@ -95,15 +92,12 @@ jobs:
 
       - name: Run Black
         run: black --check src/ tests/
-        continue-on-error: true
 
       - name: Run isort
         run: isort --check-only src/ tests/
-        continue-on-error: true
 
       - name: Run Flake8
         run: flake8 src/ tests/ --max-line-length=100 --exclude=src/llm_providers.py
-        continue-on-error: true
 
       - name: Set up Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
Remove `continue-on-error: true` from lint/format/build/test steps so failures actually block the PR.

Changes:
- Remove `continue-on-error: false` (was already the default, no-op)
- Remove `continue-on-error: true` from Build TypeScript, Run Node.js tests, Black, isort, Flake8

Without this fix, CI could silently pass even when linting or formatting fails.