### PR TITLE
fix(lint): resolve all Black/isort/flake8 issues + remove CI continue-on-error

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 120
+exclude = src/llm_providers.py
+extend-ignore = E203,E402,F841,E501

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,16 +66,13 @@ jobs:
           echo "Node version: $(node --version)"
           echo "NPM version: $(npm --version)"
           echo "Installing dependencies..."
-          npm install --verbose 2>&1 | head -100 || npm install
-        continue-on-error: false
+          npm install
 
       - name: Build TypeScript
         run: npm run build
-        continue-on-error: true
 
       - name: Run Node.js tests
         run: npm test
-        continue-on-error: true
 
   lint:
     runs-on: ubuntu-latest
@@ -95,15 +92,12 @@ jobs:
 
       - name: Run Black
         run: black --check src/ tests/
-        continue-on-error: true
 
       - name: Run isort
         run: isort --check-only src/ tests/
-        continue-on-error: true
 
       - name: Run Flake8
         run: flake8 src/ tests/ --max-line-length=100 --exclude=src/llm_providers.py
-        continue-on-error: true
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/src/agent_tools.py
+++ b/src/agent_tools.py
@@ -8,11 +8,10 @@ Author: LobsterPress Team
 Version: v4.0.41
 """
 
-import json
-import sys
 import argparse
+import json
 import logging
-from typing import List, Dict, Optional
+from typing import Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 from src.database import LobsterDatabase

--- a/src/async_queue/worker.py
+++ b/src/async_queue/worker.py
@@ -8,13 +8,12 @@
 Version: v5.0.0
 """
 
-import asyncio
+import logging
 import threading
 import time
-import logging
-from typing import Callable, Dict, Any, Optional
 from collections import deque
 from datetime import datetime, timezone
+from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
 

--- a/src/dag_compressor.py
+++ b/src/dag_compressor.py
@@ -8,15 +8,14 @@ Author: LobsterPress Team
 Version: v4.0.41
 """
 
-import json
 import logging
-from typing import List, Dict, Optional, Tuple
 from datetime import datetime, timezone
+from typing import Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 from src.database import LobsterDatabase
 from src.pipeline.event_segmenter import EventSegmenter
-from src.prompts import build_leaf_summary_prompt, build_condensed_summary_prompt
+from src.prompts import build_condensed_summary_prompt, build_leaf_summary_prompt
 
 
 class DAGCompressor:
@@ -110,7 +109,7 @@ class DAGCompressor:
             return None
 
         # 2. 分离 fresh tail 和 older messages
-        fresh_tail = messages[-self.fresh_tail_count :]
+        _fresh_tail = messages[-self.fresh_tail_count :]
         older_messages = messages[: -self.fresh_tail_count]
 
         # 3. 获取已经被压缩的消息（从 context_items 中排除）
@@ -271,7 +270,7 @@ class DAGCompressor:
             summary_parts.append(
                 f"- 助手消息: {sum(1 for m in messages if m.get('role') == 'assistant')} 条"
             )
-            summary_parts.append(f"- 生成方式: LLM (v3.2.1)")
+            summary_parts.append("- 生成方式: LLM (v3.2.1)")
             summary_parts.append("")
             summary_parts.append("### 核心内容:")
             summary_parts.append(summary)
@@ -442,7 +441,7 @@ class DAGCompressor:
             summary_parts.append(f"## 压缩摘要 (Depth {depth + 1})")
             summary_parts.append(f"- 原始长度: {len(combined_content)} 字符")
             summary_parts.append(f"- 摘要长度: {len(summary)} 字符")
-            summary_parts.append(f"- 生成方式: LLM (v3.2.1)")
+            summary_parts.append("- 生成方式: LLM (v3.2.1)")
             summary_parts.append("")
             summary_parts.append("### 核心要点:")
             summary_parts.append(summary)
@@ -495,7 +494,6 @@ class DAGCompressor:
         Returns:
             是否执行了压缩
         """
-        import sys
 
         logger.info(f"增量压缩检查: {conversation_id}")
 
@@ -838,7 +836,7 @@ class DAGCompressor:
         import json as _json
 
         combined = "\n".join(
-            f"[{m.get('role','?')}]: {m.get('content','')[:300]}" for m in messages
+            f"[{m.get('role', '?')}]: {m.get('content', '')[:300]}" for m in messages
         )
         prompt = (
             "从以下对话片段中提取所有关键实体（人名、文件路径、技术概念、重要决策）。\n"

--- a/src/database.py
+++ b/src/database.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
 """
 LobsterPress Database - 无损存储层
 借鉴 lossless-claw 的数据库设计
@@ -8,17 +11,16 @@ Author: LobsterPress Team
 Version: 5.1.0
 """
 
-import sqlite3
-import json
 import hashlib
-import uuid
-import math
-import sys
+import json
 import logging
-from typing import List, Dict, Optional, Any
-from pathlib import Path
+import math
+import sqlite3
+import uuid
 from datetime import datetime, timezone
+from typing import Dict, List, Optional
 
+from src.skills.models import Skill  # noqa: F401
 from src.utils.tokens import estimate_tokens as _estimate_tokens_shared
 
 logger = logging.getLogger(__name__)
@@ -167,7 +169,7 @@ class LobsterDatabase:
 
         # FTS5 全文搜索 - 消息
         self.cursor.execute("""
-            CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts 
+            CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts
             USING fts5(
                 message_id,
                 content,
@@ -178,7 +180,7 @@ class LobsterDatabase:
 
         # FTS5 全文搜索 - 摘要
         self.cursor.execute("""
-            CREATE VIRTUAL TABLE IF NOT EXISTS summaries_fts 
+            CREATE VIRTUAL TABLE IF NOT EXISTS summaries_fts
             USING fts5(
                 summary_id,
                 content,
@@ -282,12 +284,12 @@ class LobsterDatabase:
 
         # 创建索引
         self.cursor.execute("""
-            CREATE INDEX IF NOT EXISTS idx_messages_conversation 
+            CREATE INDEX IF NOT EXISTS idx_messages_conversation
             ON messages(conversation_id, seq);
         """)
 
         self.cursor.execute("""
-            CREATE INDEX IF NOT EXISTS idx_summaries_conversation 
+            CREATE INDEX IF NOT EXISTS idx_summaries_conversation
             ON summaries(conversation_id, depth);
         """)
 
@@ -373,7 +375,7 @@ class LobsterDatabase:
         """)
 
         self.cursor.execute("""
-            CREATE INDEX IF NOT EXISTS idx_corrections_target 
+            CREATE INDEX IF NOT EXISTS idx_corrections_target
             ON corrections(target_type, target_id)
         """)
 
@@ -663,8 +665,8 @@ class LobsterDatabase:
             消息列表
         """
         query = """
-            SELECT * FROM messages 
-            WHERE conversation_id = ? 
+            SELECT * FROM messages
+            WHERE conversation_id = ?
             ORDER BY seq ASC
         """
         # v4.0.13: 修复 SQL 注入风险（Issue #151 Bug #3）
@@ -854,7 +856,8 @@ class LobsterDatabase:
         structure_score = 0.0
         if "```" in content or "    " in content:  # 代码块
             structure_score += 0.5
-        if any(content.count(marker) > 2 for marker in ["- ", "* ", "1. "]):  # 列表
+        # 列表
+        if any(content.count(marker) > 2 for marker in ["- ", "* ", "1. "]):
             structure_score += 0.3
         if content.count("\n") > 5:  # 多段落
             structure_score += 0.2
@@ -941,8 +944,8 @@ class LobsterDatabase:
             # 执行 UPSERT（v4.0.2: 补充 r3_layer 和 memory_tier）
             self.cursor.execute(
                 """
-                INSERT OR REPLACE INTO summaries 
-                (summary_id, conversation_id, kind, depth, content, token_count, 
+                INSERT OR REPLACE INTO summaries
+                (summary_id, conversation_id, kind, depth, content, token_count,
                  earliest_at, latest_at, descendant_count, created_at,
                  r3_layer, memory_tier)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -1010,7 +1013,7 @@ class LobsterDatabase:
         if depth is not None:
             self.cursor.execute(
                 """
-                SELECT * FROM summaries 
+                SELECT * FROM summaries
                 WHERE conversation_id = ? AND depth = ?
                 ORDER BY created_at ASC
             """,
@@ -1019,7 +1022,7 @@ class LobsterDatabase:
         else:
             self.cursor.execute(
                 """
-                SELECT * FROM summaries 
+                SELECT * FROM summaries
                 WHERE conversation_id = ?
                 ORDER BY depth ASC, created_at ASC
             """,
@@ -1434,7 +1437,7 @@ class LobsterDatabase:
             # 记录纠错（直接带 applied_at，避免两次 UPDATE）
             self.cursor.execute(
                 """
-                INSERT INTO corrections 
+                INSERT INTO corrections
                 (correction_id, target_type, target_id, correction_type, old_value, new_value, reason, created_at, applied_at)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
@@ -1585,6 +1588,7 @@ class LobsterDatabase:
             清理统计
         """
         from datetime import datetime, timedelta, timezone
+
         from pipeline.chlr_scorer import CHLRScorer
 
         cutoff_date = (datetime.now(timezone.utc) - timedelta(days=days_threshold)).isoformat()
@@ -1594,7 +1598,7 @@ class LobsterDatabase:
         # 查找候选消息（增加 conversation_id 过滤 + 近期保护）
         self.cursor.execute(
             """
-            SELECT message_id, token_count, tfidf_score, access_count, 
+            SELECT message_id, token_count, tfidf_score, access_count,
                    last_accessed_at, created_at, content, metadata, memory_tier
             FROM messages
             WHERE conversation_id = ?
@@ -1650,7 +1654,7 @@ class LobsterDatabase:
 
             # 计算半衰期和保留率
             half_life = scorer.calculate_half_life(message)
-            retention = scorer.calculate_retention(message)
+            scorer.calculate_retention(message)
 
             # 更新 half_life 字段
             self.cursor.execute(
@@ -1874,7 +1878,7 @@ class LobsterDatabase:
                     elif block.get("type") == "toolCall":
                         texts.append(f"[Tool Call: {block.get('name', 'unknown')}]")
                     elif block.get("type") == "thinking":
-                        texts.append(f"[Thinking]")
+                        texts.append("[Thinking]")
             return "\n".join(texts)
 
         return str(content)
@@ -2133,6 +2137,7 @@ class LobsterDatabase:
     ) -> List[Dict]:
         """纯内存余弦相似度搜索"""
         import struct
+
         import numpy as np
 
         query = "SELECT chunk_id, target_type, target_id, vector FROM embeddings"

--- a/src/incremental_compressor.py
+++ b/src/incremental_compressor.py
@@ -9,19 +9,19 @@ Version: v4.0.41
 """
 
 import logging
-from typing import Dict, Optional
 from datetime import datetime, timezone
+from typing import Dict, Optional
 
 logger = logging.getLogger(__name__)
-from src.database import LobsterDatabase
 from src.dag_compressor import DAGCompressor
-from src.pipeline.tfidf_scorer import TFIDFScorer, EXEMPT_TYPES
+from src.database import LobsterDatabase
 from src.pipeline.semantic_dedup import SemanticDeduplicator
+from src.pipeline.tfidf_scorer import TFIDFScorer
 
 # v3.0.0: 语义记忆和矛盾检测
 try:
-    from src.semantic_memory import SemanticMemory
     from src.pipeline.conflict_detector import ConflictDetector
+    from src.semantic_memory import SemanticMemory
 
     SEMANTIC_MEMORY_AVAILABLE = True
 except ImportError:

--- a/src/llm_client.py
+++ b/src/llm_client.py
@@ -11,10 +11,10 @@ Author: LobsterPress Team
 Version: v4.0.41
 """
 
-import os
 import logging
+import os
 from abc import ABC, abstractmethod
-from typing import Optional, Dict, Any
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -33,12 +33,10 @@ class BaseLLMClient(ABC):
         Returns:
             生成的文本
         """
-        pass
 
     @abstractmethod
     def is_available(self) -> bool:
         """检查客户端是否可用"""
-        pass
 
 
 class MockLLMClient(BaseLLMClient):

--- a/src/llm_providers.py
+++ b/src/llm_providers.py
@@ -11,9 +11,9 @@ Author: LobsterPress Team
 Version: v5.0.0
 """
 
-import os
 import logging
-from typing import Optional, Dict, Any
+import os
+from typing import Optional
 
 from src.llm_client import BaseLLMClient
 
@@ -210,8 +210,8 @@ class BaiduClient(BaseLLMClient):
 
     def _get_access_token(self):
         if self._access_token is None:
-            import urllib.request
             import json as _json
+            import urllib.request
 
             url = (
                 "https://aip.baidubce.com/oauth/2.0/token"
@@ -225,8 +225,8 @@ class BaiduClient(BaseLLMClient):
         return self._access_token
 
     def generate(self, prompt: str, **kwargs) -> str:
-        import urllib.request
         import json as _json
+        import urllib.request
 
         access_token = self._get_access_token()
         url = (

--- a/src/migration/importer.py
+++ b/src/migration/importer.py
@@ -7,13 +7,13 @@ OpenClaw 原生记忆导入器
 Version: v5.0.0
 """
 
-import sqlite3
-import json
 import hashlib
+import json
 import logging
-from pathlib import Path
-from typing import Dict, List, Optional, Callable
+import sqlite3
 from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Dict
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +63,7 @@ class MemoryImporter:
 
                 # 检查 messages 表是否存在
                 cursor.execute("""
-                    SELECT COUNT(*) FROM sqlite_master 
+                    SELECT COUNT(*) FROM sqlite_master
                     WHERE type='table' AND name='messages'
                 """)
                 if cursor.fetchone()[0] == 0:
@@ -78,7 +78,7 @@ class MemoryImporter:
                 stats["messages"] += count
 
                 conn.close()
-            except Exception as e:
+            except Exception:
                 stats["errors"] += 1
                 continue
 
@@ -136,7 +136,7 @@ class MemoryImporter:
             # 获取消息
             cursor.execute("""
                 SELECT message_id, role, content, created_at, metadata
-                FROM messages 
+                FROM messages
                 ORDER BY created_at ASC
             """)
             rows = cursor.fetchall()
@@ -166,7 +166,7 @@ class MemoryImporter:
                     self._import_message(msg, content_hash)
                     processed_hashes.add(content_hash)
                     self._progress["stored"] += 1
-                except Exception as e:
+                except Exception:
                     self._progress["errors"] += 1
 
         finally:

--- a/src/pipeline/__init__.py
+++ b/src/pipeline/__init__.py
@@ -8,9 +8,9 @@ LobsterPress Pipeline - v2.5.0 智能压缩流水线
 - BatchImporter: 历史数据迁移
 """
 
-from .tfidf_scorer import TFIDFScorer, ScoredMessage, EXEMPT_TYPES
-from .semantic_dedup import SemanticDeduplicator
 from .batch_importer import BatchImporter
+from .semantic_dedup import SemanticDeduplicator
+from .tfidf_scorer import EXEMPT_TYPES, ScoredMessage, TFIDFScorer
 
 __all__ = [
     "TFIDFScorer",

--- a/src/pipeline/batch_importer.py
+++ b/src/pipeline/batch_importer.py
@@ -16,17 +16,16 @@ Author: LobsterPress Team
 Version: v2.5.0
 """
 
-import sys
-import os
-import json
 import csv
+import json
 import logging
+import sys
 from datetime import datetime, timezone
-from typing import List, Dict, Optional, Iterator
+from typing import Dict, List
 
 logger = logging.getLogger(__name__)
 from src.database import LobsterDatabase
-from src.pipeline.tfidf_scorer import TFIDFScorer, ScoredMessage
+from src.pipeline.tfidf_scorer import TFIDFScorer
 
 
 class BatchImporter:

--- a/src/pipeline/chlr_scorer.py
+++ b/src/pipeline/chlr_scorer.py
@@ -9,9 +9,8 @@ CHLRScorer — C-HLR+ 自适应半衰期回归算法
 v4.0.96: 首次实现
 """
 
-import math
+from datetime import datetime, timezone
 from typing import Dict, List
-from datetime import datetime, timedelta, timezone
 
 
 class CHLRScorer:

--- a/src/pipeline/conflict_detector.py
+++ b/src/pipeline/conflict_detector.py
@@ -13,11 +13,11 @@ Author: LobsterPress Team
 Version: v3.0.0
 """
 
-import re
 import logging
-from typing import List, Dict, Optional
+import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from typing import Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 

--- a/src/pipeline/event_segmenter.py
+++ b/src/pipeline/event_segmenter.py
@@ -12,12 +12,11 @@ Author: LobsterPress Team
 Version: v2.6.0
 """
 
-import re
-import math
 import logging
-from typing import List, Dict, Optional
-from datetime import datetime
+import re
 from collections import Counter
+from datetime import datetime
+from typing import Dict, List, Optional
 
 from src.utils.math import cosine_similarity
 from src.utils.tokens import estimate_tokens

--- a/src/pipeline/intent_extractor.py
+++ b/src/pipeline/intent_extractor.py
@@ -7,11 +7,11 @@ LobsterPress - Intent Extractor
 - HiMem：关键信息提取
 """
 
-import re
 import json
-from typing import List, Dict, Optional, Tuple
-from dataclasses import dataclass, field
+import re
 from collections import Counter
+from dataclasses import dataclass, field
+from typing import Dict, List
 
 
 @dataclass

--- a/src/pipeline/semantic_dedup.py
+++ b/src/pipeline/semantic_dedup.py
@@ -12,10 +12,8 @@ Author: LobsterPress Team
 Version: v2.5.0
 """
 
-import math
 import logging
-from typing import List, Tuple, Set
-from collections import Counter
+from typing import List, Set, Tuple
 
 from src.utils.math import cosine_similarity
 

--- a/src/pipeline/tfidf_scorer.py
+++ b/src/pipeline/tfidf_scorer.py
@@ -13,16 +13,16 @@ Author: LobsterPress Team
 Version: v2.5.0
 """
 
-import re
-import math
-import time
 import logging
-from datetime import datetime
+import math
+import re
+import time
 from collections import Counter
+from datetime import datetime
 
 logger = logging.getLogger(__name__)
-from typing import List, Dict, Union
 from dataclasses import dataclass
+from typing import Dict, List, Union
 
 from src.utils.math import cosine_similarity
 

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -10,7 +10,7 @@ Version: v4.0.41
 """
 
 import logging
-from typing import List, Dict
+from typing import Dict, List
 
 from src.utils.tokens import estimate_tokens
 

--- a/src/semantic_memory.py
+++ b/src/semantic_memory.py
@@ -10,11 +10,11 @@ Author: LobsterPress Team
 Version: v4.0.41
 """
 
-import json
 import hashlib
+import json
 import logging
-from typing import List, Dict, Optional
 from datetime import datetime, timezone
+from typing import Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 # v3.2.1: 使用集中的 prompt 模块

--- a/src/skills/evolver.py
+++ b/src/skills/evolver.py
@@ -7,10 +7,10 @@
 Version: v5.0.0
 """
 
-import json
 import hashlib
-from typing import List, Dict, Optional
+import json
 from datetime import datetime, timezone
+from typing import Dict, Optional
 
 
 class SkillEvolver:

--- a/src/skills/models.py
+++ b/src/skills/models.py
@@ -10,8 +10,7 @@ Version: v5.0.0
 """
 
 from dataclasses import dataclass, field
-from typing import List, Optional
-from datetime import datetime
+from typing import List
 
 
 @dataclass

--- a/src/skills/task_detector.py
+++ b/src/skills/task_detector.py
@@ -8,8 +8,8 @@ Version: v5.0.0
 """
 
 import json
-from typing import List, Dict, Optional
 from datetime import datetime
+from typing import Dict, List, Optional
 
 
 class TaskDetector:

--- a/src/three_pass_trimmer.py
+++ b/src/three_pass_trimmer.py
@@ -7,10 +7,10 @@ ThreePassTrimmer — 基于 CMV 论文(arXiv:2602.22402)的三遍无损压缩引
 arXiv: https://arxiv.org/abs/2602.22402
 """
 
-import re
-import json
 import hashlib
-from typing import List, Dict, Tuple
+import json
+import re
+from typing import Dict, List, Tuple
 
 
 class ThreePassTrimmer:
@@ -310,7 +310,6 @@ class ThreePassTrimmer:
         例如：每轮都注入的 [MEMORY REMINDER] 或 <system-reminder>，
         只保留最后一次，其余替换为 '[boilerplate folded]'。
         """
-        result = []
         saved = 0
         seen_boilerplate = set()
 

--- a/src/vector/__init__.py
+++ b/src/vector/__init__.py
@@ -2,8 +2,8 @@
 
 from .embedder import (
     BaseEmbedder,
-    OpenAICompatibleEmbedder,
     NumpyOfflineEmbedder,
+    OpenAICompatibleEmbedder,
     create_embedder,
 )
 from .retriever import HybridRetriever

--- a/src/vector/embedder.py
+++ b/src/vector/embedder.py
@@ -1,11 +1,12 @@
 """Vector embedding module for lobster-press."""
 
-import os
 import logging
-import numpy as np
-import requests
+import os
 from abc import ABC, abstractmethod
 from typing import List
+
+import numpy as np
+import requests
 
 logger = logging.getLogger(__name__)
 EMBEDDING_DIM = 1024
@@ -17,17 +18,14 @@ class BaseEmbedder(ABC):
     @abstractmethod
     def embed(self, text: str) -> List[float]:
         """Generate embedding for a single text."""
-        pass
 
     @abstractmethod
     def embed_batch(self, texts: List[str]) -> List[List[float]]:
         """Generate embeddings for a batch of texts."""
-        pass
 
     @abstractmethod
     def is_available(self) -> bool:
         """Check if the embedder is available."""
-        pass
 
 
 class OpenAICompatibleEmbedder(BaseEmbedder):

--- a/src/vector/retriever.py
+++ b/src/vector/retriever.py
@@ -8,9 +8,8 @@ Version: v5.0.0
 """
 
 import math
-import numpy as np
-from typing import List, Dict, Optional, Tuple
 from datetime import datetime, timezone
+from typing import Dict, List
 
 
 class HybridRetriever:

--- a/src/viewer/server.py
+++ b/src/viewer/server.py
@@ -12,12 +12,11 @@ Version: v5.0.0
 
 import hashlib
 import json
-import re
 import logging
-from http.server import HTTPServer, BaseHTTPRequestHandler
-from urllib.parse import urlparse, parse_qs
-from typing import Optional, Dict, Any
 from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Dict
+from urllib.parse import parse_qs, urlparse
 
 logger = logging.getLogger(__name__)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,9 +8,10 @@ from pathlib import Path
 # Add project root to Python path for CI environments
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-import pytest
-import tempfile
 import os
+import tempfile
+
+import pytest
 
 from src.database import LobsterDatabase
 from src.llm_client import MockLLMClient

--- a/tests/contract/conftest.py
+++ b/tests/contract/conftest.py
@@ -9,14 +9,15 @@ from pathlib import Path
 # 添加项目根目录到 Python 路径
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
-import pytest
-import tempfile
 import os
+import tempfile
 
+import pytest
+
+from mcp_server.lobster_mcp_server import LobsterPressMCPServer
+from src.dag_compressor import DAGCompressor
 from src.database import LobsterDatabase
 from src.llm_client import MockLLMClient
-from src.dag_compressor import DAGCompressor
-from mcp_server.lobster_mcp_server import LobsterPressMCPServer
 
 
 @pytest.fixture

--- a/tests/contract/test_lobster_assemble_contract.py
+++ b/tests/contract/test_lobster_assemble_contract.py
@@ -4,8 +4,8 @@
 验证 lobster_assemble 工具的响应结构符合 MCP 协议规范。
 """
 
-import json
 import asyncio
+import json
 
 
 def test_response_has_required_fields(mcp_server, sample_conversation_id):

--- a/tests/contract/test_lobster_compress_contract.py
+++ b/tests/contract/test_lobster_compress_contract.py
@@ -10,8 +10,8 @@ lobster_compress 是 v3.3.0 引入的增量压缩工具。
 - 可选字段：tokens_saved (int), compression_ratio (float)
 """
 
-import json
 import asyncio
+import json
 
 
 def test_response_has_required_fields(mcp_server, sample_conversation_id):

--- a/tests/contract/test_lobster_correct_contract.py
+++ b/tests/contract/test_lobster_correct_contract.py
@@ -9,8 +9,8 @@ lobster_correct 用于应用记忆纠错（修改或删除错误记忆）。
 - 返回纠错结果或错误信息
 """
 
-import json
 import asyncio
+import json
 
 
 def test_response_has_required_fields(mcp_server):

--- a/tests/contract/test_lobster_describe_contract.py
+++ b/tests/contract/test_lobster_describe_contract.py
@@ -9,8 +9,8 @@ lobster_describe 用于查看 DAG 摘要层级结构。
 - 返回 DAG 节点信息或错误信息
 """
 
-import json
 import asyncio
+import json
 
 
 def test_response_has_required_fields(mcp_server):

--- a/tests/contract/test_lobster_expand_contract.py
+++ b/tests/contract/test_lobster_expand_contract.py
@@ -9,8 +9,8 @@ lobster_expand 用于将 DAG 摘要节点展开，还原原始消息（无损检
 - 返回展开的消息列表或错误信息
 """
 
-import json
 import asyncio
+import json
 
 
 def test_response_has_required_fields(mcp_server):

--- a/tests/contract/test_lobster_grep_contract.py
+++ b/tests/contract/test_lobster_grep_contract.py
@@ -9,8 +9,8 @@ lobster_grep 是 FTS5 全文搜索工具，支持 TF-IDF 重排序。
 - 必需字段：results (array)
 """
 
-import json
 import asyncio
+import json
 
 
 def test_response_has_required_fields(mcp_server):

--- a/tests/contract/test_lobster_ingest_contract.py
+++ b/tests/contract/test_lobster_ingest_contract.py
@@ -2,8 +2,8 @@
 契约测试：lobster_ingest MCP 工具
 """
 
-import json
 import asyncio
+import json
 
 
 def test_response_has_required_fields(mcp_server):

--- a/tests/contract/test_lobster_prune_contract.py
+++ b/tests/contract/test_lobster_prune_contract.py
@@ -9,8 +9,8 @@ lobster_prune 用于删除已标记为 decayed 的消息，释放存储空间（
 - 必需字段：dry_run, decayed_count (dry_run) 或 deleted_count (实际删除)
 """
 
-import json
 import asyncio
+import json
 
 
 def test_response_has_required_fields(mcp_server, sample_conversation_id):

--- a/tests/contract/test_lobster_status_contract.py
+++ b/tests/contract/test_lobster_status_contract.py
@@ -9,8 +9,8 @@ lobster_status 返回系统健康报告，包含记忆分布、压缩统计等�
 - 必需字段：version, tier_distribution
 """
 
-import json
 import asyncio
+import json
 
 
 def test_response_has_required_fields(mcp_server):

--- a/tests/contract/test_lobster_sweep_contract.py
+++ b/tests/contract/test_lobster_sweep_contract.py
@@ -9,8 +9,8 @@ lobster_sweep 用于清理衰减消息（基于遗忘曲线，标记低价值消
 - 返回清理结果或错误信息
 """
 
-import json
 import asyncio
+import json
 
 
 def test_response_has_required_fields(mcp_server, sample_conversation_id):

--- a/tests/integration/test_agent_tools.py
+++ b/tests/integration/test_agent_tools.py
@@ -4,17 +4,17 @@
 LobsterPress Agent Tools 测试脚本
 """
 
-import sys
 import os
-from pathlib import Path
+import sys
 from datetime import datetime, timezone
+from pathlib import Path
 
 # 添加 src 目录
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
 
-from database import LobsterDatabase
+from agent_tools import lobster_describe, lobster_expand, lobster_grep
 from dag_compressor import DAGCompressor
-from agent_tools import lobster_grep, lobster_describe, lobster_expand
+from database import LobsterDatabase
 
 
 def test_agent_tools():
@@ -35,12 +35,12 @@ def test_agent_tools():
 
     # 创建测试数据
     conversation_id = "conv_test"
-    print(f"\n📝 创建测试数据...\n")
+    print("\n📝 创建测试数据...\n")
 
     for i in range(1, 31):
         content = f"这是第 {i} 条消息，讨论了技术话题 {i % 10}。"
         if i % 5 == 0:
-            content += f" 关键词: Python, JavaScript, Rust, Go"
+            content += " 关键词: Python, JavaScript, Rust, Go"
 
         msg = {
             "id": f"msg_{i:03d}",
@@ -62,7 +62,7 @@ def test_agent_tools():
         )
 
     db.conn.commit()
-    print(f"✅ 创建了 30 条测试消息\n")
+    print("✅ 创建了 30 条测试消息\n")
 
     # 执行压缩
     print("=" * 60)
@@ -149,7 +149,7 @@ def test_agent_tools():
         print(f"  摘要 ID: {result['summary_id']}")
         print(f"  总消息数: {result['total_messages']}")
         print(f"  访问摘要: {result['visited_summaries']}")
-        print(f"  前 3 条消息:")
+        print("  前 3 条消息:")
         for i, msg in enumerate(result["messages"][:3], 1):
             print(f"    {i}. [{msg['role']}] {msg['content'][:60]}...")
 
@@ -168,21 +168,21 @@ def test_agent_tools():
     print("  ✅ 测试完成")
     print("=" * 60)
 
-    print(f"\n📊 测试统计:")
-    print(f"  - 消息数: 30 条")
+    print("\n📊 测试统计:")
+    print("  - 消息数: 30 条")
     print(f"  - 叶子摘要: {stats['leaf_summaries']} 个")
     print(f"  - 压缩摘要: {stats['condensed_summaries']} 个")
     print(f"  - 压缩消息: {stats['messages_compressed']} 条")
 
-    print(f"\n🔧 工具测试:")
-    print(f"  - lobster_grep: ✅ 搜索功能正常")
-    print(f"  - lobster_describe: ✅ 查看摘要正常")
-    print(f"  - lobster_expand: ✅ 展开功能正常")
+    print("\n🔧 工具测试:")
+    print("  - lobster_grep: ✅ 搜索功能正常")
+    print("  - lobster_describe: ✅ 查看摘要正常")
+    print("  - lobster_expand: ✅ 展开功能正常")
 
     # 清理
     db.close()
     os.remove("test_tools.db")
-    print(f"\n🗑️ 清理测试数据库")
+    print("\n🗑️ 清理测试数据库")
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_core_workflows.py
+++ b/tests/integration/test_core_workflows.py
@@ -14,14 +14,15 @@ Date: 2026-03-19
 """
 
 import sys
-import pytest
 from pathlib import Path
+
+import pytest
 
 # 添加 src 目录到 path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
 
-from database import LobsterDatabase
 from dag_compressor import DAGCompressor
+from database import LobsterDatabase
 from incremental_compressor import IncrementalCompressor
 from three_pass_trimmer import ThreePassTrimmer
 
@@ -37,11 +38,11 @@ class TestMessageWorkflow:
     def test_add_and_retrieve_messages(self, db):
         """测试添加和检索消息"""
         # 1. 添加消息
-        msg_id_1 = db.add_message(
+        _msg_id_1 = db.add_message(
             conversation_id="conv_1", role="user", content="Hello, this is a test"
         )
 
-        msg_id_2 = db.add_message(
+        _msg_id_2 = db.add_message(
             conversation_id="conv_1", role="assistant", content="Hi, I received your message"
         )
 
@@ -165,7 +166,7 @@ class TestSummaryWorkflow:
         )
 
         # 3. 创建压缩摘要
-        condensed_summary = db.save_summary(
+        _condensed_summary = db.save_summary(
             {
                 "summary_id": "sum_condensed_1",
                 "conversation_id": "conv_1",
@@ -351,7 +352,7 @@ class TestErrorHandling:
     def test_message_with_empty_content(self, db):
         """测试空内容的消息"""
         # 1. 添加空内容消息
-        msg_id = db.add_message(conversation_id="conv_1", role="user", content="")
+        _msg_id = db.add_message(conversation_id="conv_1", role="user", content="")
 
         # 2. 验证消息被添加
         messages = db.get_messages("conv_1")

--- a/tests/integration/test_issue_174.py
+++ b/tests/integration/test_issue_174.py
@@ -15,13 +15,14 @@ Author: LobsterPress Team
 Version: v4.0.37
 """
 
-import pytest
-import tempfile
 import os
-from pathlib import Path
 
 # 添加项目根目录到路径
 import sys
+import tempfile
+from pathlib import Path
+
+import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
@@ -35,7 +36,7 @@ class TestIssue174Fixes:
 
     def test_fix1_decision_keywords_not_dead_code(self):
         """Fix 1: 验证 DECISION_KEYWORDS 不是死代码"""
-        compressor = DAGCompressor.__new__(DAGCompressor)
+        DAGCompressor.__new__(DAGCompressor)
 
         # 验证 DECISION_KEYWORDS 存在
         assert hasattr(DAGCompressor, "DECISION_KEYWORDS")
@@ -86,7 +87,7 @@ class TestIssue174Fixes:
 
         # 分词
         chinese_tokens = scorer.tokenize(chinese_text)
-        english_tokens = scorer.tokenize(english_text)
+        scorer.tokenize(english_text)
 
         # 验证中文 bi-gram 提取
         chinese_bigrams = [

--- a/tests/integration/test_llm_integration.py
+++ b/tests/integration/test_llm_integration.py
@@ -9,21 +9,21 @@ Author: LobsterPress Team
 Version: v3.2.1
 """
 
-import sys
 import os
+import sys
 
 import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "src"))
 
+from src.llm_client import create_llm_client
 from src.prompts import (
-    build_leaf_summary_prompt,
     build_condensed_summary_prompt,
+    build_leaf_summary_prompt,
     build_note_extraction_prompt,
     estimate_tokens,
     truncate_messages,
 )
-from src.llm_client import create_llm_client
 
 # 测试数据
 TEST_MESSAGES = [
@@ -56,7 +56,7 @@ def test_prompt_building():
 
     # 1. 叶子摘要 prompt
     leaf_prompt = build_leaf_summary_prompt(TEST_MESSAGES)
-    print(f"\n✅ 叶子摘要 Prompt 构建成功")
+    print("\n✅ 叶子摘要 Prompt 构建成功")
     print(f"   长度: {len(leaf_prompt)} 字符")
     print(f"   预估 tokens: {estimate_tokens(leaf_prompt)}")
     assert "对话摘要" in leaf_prompt
@@ -64,14 +64,14 @@ def test_prompt_building():
 
     # 2. 压缩摘要 prompt
     condensed_prompt = build_condensed_summary_prompt(TEST_COMBINED_CONTENT, depth=1)
-    print(f"\n✅ 压缩摘要 Prompt 构建成功")
+    print("\n✅ 压缩摘要 Prompt 构建成功")
     print(f"   长度: {len(condensed_prompt)} 字符")
     print(f"   预估 tokens: {estimate_tokens(condensed_prompt)}")
     assert "Level 1" in condensed_prompt
 
     # 3. Note 提取 prompt
     note_prompt = build_note_extraction_prompt(TEST_MESSAGES)
-    print(f"\n✅ Note 提取 Prompt 构建成功")
+    print("\n✅ Note 提取 Prompt 构建成功")
     print(f"   长度: {len(note_prompt)} 字符")
     print(f"   预估 tokens: {estimate_tokens(note_prompt)}")
     assert "稳定的语义知识" in note_prompt
@@ -112,12 +112,12 @@ def test_llm_integration_with_deepseek():
     try:
         # 创建客户端
         client = create_llm_client(provider="deepseek", api_key=api_key, model="deepseek-chat")
-        print(f"✅ DeepSeek 客户端创建成功")
+        print("✅ DeepSeek 客户端创建成功")
 
         # 测试叶子摘要生成
         prompt = build_leaf_summary_prompt(TEST_MESSAGES[:2])
         result = client.generate(prompt, temperature=0.7, max_tokens=300)
-        print(f"\n✅ 叶子摘要生成成功")
+        print("\n✅ 叶子摘要生成成功")
         print(f"   响应长度: {len(result)} 字符")
         print(f"   预览: {result[:100]}...")
 
@@ -142,12 +142,12 @@ def test_llm_integration_with_zhipu():
     try:
         # 创建客户端
         client = create_llm_client(provider="zhipu", api_key=api_key, model="glm-4-flash")
-        print(f"✅ 智谱 GLM 客户端创建成功")
+        print("✅ 智谱 GLM 客户端创建成功")
 
         # 测试 Note 提取
         prompt = build_note_extraction_prompt(TEST_MESSAGES[:2])
         result = client.generate(prompt, temperature=0.5, max_tokens=500)
-        print(f"\n✅ Note 提取成功")
+        print("\n✅ Note 提取成功")
         print(f"   响应长度: {len(result)} 字符")
         print(f"   预览: {result[:150]}...")
 

--- a/tests/integration/test_real_llm.py
+++ b/tests/integration/test_real_llm.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """实际 LLM API 调用测试"""
 
-import sys
 import os
+import sys
+
 import pytest
 
 _project_root = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
@@ -41,21 +42,21 @@ def test_deepseek():
             provider="deepseek", api_key=DEEPSEEK_API_KEY, model="deepseek-chat"
         )
 
-        print(f"✅ 客户端创建成功")
-        print(f"   Provider: DeepSeek")
-        print(f"   Model: deepseek-chat")
+        print("✅ 客户端创建成功")
+        print("   Provider: DeepSeek")
+        print("   Model: deepseek-chat")
         # v4.0.9: 移除 API Key 打印（CodeQL 安全警告）
 
         # 调用 API
-        print(f"\n📤 发送请求...")
+        print("\n📤 发送请求...")
         result = client.generate(TEST_PROMPT, temperature=0.7, max_tokens=200)
 
-        print(f"\n✅ API 调用成功！")
-        print(f"\n📝 生成结果：")
+        print("\n✅ API 调用成功！")
+        print("\n📝 生成结果：")
         print("-" * 60)
         print(result)
         print("-" * 60)
-        print(f"\n📊 统计：")
+        print("\n📊 统计：")
         print(f"   响应长度: {len(result)} 字符")
 
     except Exception as e:
@@ -76,21 +77,21 @@ def test_zhipu():
         # 创建客户端
         client = create_llm_client(provider="zhipu", api_key=ZHIPU_API_KEY, model="glm-4-flash")
 
-        print(f"✅ 客户端创建成功")
-        print(f"   Provider: 智谱 GLM")
-        print(f"   Model: glm-4-flash")
+        print("✅ 客户端创建成功")
+        print("   Provider: 智谱 GLM")
+        print("   Model: glm-4-flash")
         # v4.0.9: 移除 API Key 打印（CodeQL 安全警告）
 
         # 调用 API
-        print(f"\n📤 发送请求...")
+        print("\n📤 发送请求...")
         result = client.generate(TEST_PROMPT, temperature=0.7, max_tokens=200)
 
-        print(f"\n✅ API 调用成功！")
-        print(f"\n📝 生成结果：")
+        print("\n✅ API 调用成功！")
+        print("\n📝 生成结果：")
         print("-" * 60)
         print(result)
         print("-" * 60)
-        print(f"\n📊 统计：")
+        print("\n📊 统计：")
         print(f"   响应长度: {len(result)} 字符")
 
     except Exception as e:

--- a/tests/integration/test_v25_integration.py
+++ b/tests/integration/test_v25_integration.py
@@ -13,19 +13,18 @@ Author: LobsterPress Team
 Version: v2.5.0
 """
 
-import sys
 import os
+import sys
 import unittest
-from pathlib import Path
 from datetime import datetime, timezone
+from pathlib import Path
 
 # 添加 src 模块
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
+from pipeline.tfidf_scorer import EXEMPT_TYPES
 from src.database import LobsterDatabase
 from src.incremental_compressor import IncrementalCompressor
-from src.agent_tools import lobster_grep
-from pipeline.tfidf_scorer import EXEMPT_TYPES
 
 
 class TestV25Integration(unittest.TestCase):
@@ -209,13 +208,13 @@ def connect_db():
                     mock_results[i]["relevance"], mock_results[i + 1]["relevance"]
                 )
 
-        print(f"\n  模拟搜索结果（按相关性排序）:")
+        print("\n  模拟搜索结果（按相关性排序）:")
         for result in mock_results:
             print(
                 f"    - {result['id']}: relevance={result['relevance']:.2f}, tfidf={result['tfidf_score']:.2f}"
             )
 
-        print(f"\n  ✅ 重排序逻辑正确")
+        print("\n  ✅ 重排序逻辑正确")
 
     def test_05_incremental_workflow(self):
         """测试增量压缩完整流程"""
@@ -248,7 +247,7 @@ def connect_db():
             self.assertIn("msg_type", msg)
             self.assertIn("compression_exempt", msg)
 
-        print(f"  ✅ 所有消息都已评分和打标签")
+        print("  ✅ 所有消息都已评分和打标签")
 
 
 if __name__ == "__main__":

--- a/tests/regression/test_issue_165.py
+++ b/tests/regression/test_issue_165.py
@@ -8,18 +8,16 @@
 - TC-P06: lobster_ingest(conversation_id, messages=[]) 写入验证
 """
 
-import sys
-import os
-import json
 import asyncio
+import sys
 from pathlib import Path
 
 # 添加 src 目录到 path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "mcp_server"))
 
-from database import LobsterDatabase
 from agent_tools import lobster_describe, lobster_expand
+from database import LobsterDatabase
 
 
 class TestTCP03:
@@ -102,8 +100,9 @@ class TestTCP05:
 
     def test_lobster_compress_force_reduces_message_count(self):
         """验证强制压缩后消息数下降"""
-        from dag_compressor import DAGCompressor
         from unittest.mock import Mock
+
+        from dag_compressor import DAGCompressor
 
         db = LobsterDatabase(":memory:")
         conv_id = "test_conv_compress"
@@ -228,7 +227,7 @@ class TestTCP06:
         async def run_test():
             # 测试缺少 conversation_id
             try:
-                result = await server._call_tool(
+                _result = await server._call_tool(
                     "lobster_ingest", {"messages": [{"role": "user", "content": "test"}]}
                 )
                 assert False, "Should raise ValueError for missing conversation_id"

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -6,10 +6,12 @@ LobsterPress 性能测试
 2. 批量压缩性能优化: 6.67x
 """
 
-import pytest
 import time
-from src.database import LobsterDatabase
+
+import pytest
+
 from src.dag_compressor import DAGCompressor
+from src.database import LobsterDatabase
 
 
 class TestCompressionRatio:

--- a/tests/unit/test_agent_tools.py
+++ b/tests/unit/test_agent_tools.py
@@ -7,10 +7,11 @@ import os
 import subprocess
 import sys
 import tempfile
+
 import pytest
 
+from src.agent_tools import lobster_describe, lobster_expand, lobster_grep
 from src.database import LobsterDatabase
-from src.agent_tools import lobster_grep, lobster_describe, lobster_expand, main
 
 
 @pytest.fixture

--- a/tests/unit/test_async_queue.py
+++ b/tests/unit/test_async_queue.py
@@ -2,10 +2,8 @@
 Unit tests for AsyncWorker module.
 """
 
-import pytest
 import time
 from unittest.mock import MagicMock, patch
-from collections import deque
 
 
 class TestAsyncWorkerStartStop:
@@ -285,6 +283,7 @@ class TestErrorHandling:
     def test_exceptions_in_process_are_caught_and_logged(self):
         """Exceptions in _process should be caught and logged via _run_loop."""
         import threading
+
         from src.async_queue import AsyncWorker
 
         worker = AsyncWorker(db=MagicMock())
@@ -318,7 +317,7 @@ class TestErrorHandling:
         worker.start()
 
         call_count = [0]
-        original_process = worker._process
+        worker._process
 
         def track_process(task):
             call_count[0] += 1

--- a/tests/unit/test_batch_importer.py
+++ b/tests/unit/test_batch_importer.py
@@ -5,6 +5,7 @@
 import json
 import os
 import tempfile
+
 import pytest
 
 from src.pipeline.batch_importer import BatchImporter

--- a/tests/unit/test_chlr_scorer.py
+++ b/tests/unit/test_chlr_scorer.py
@@ -2,9 +2,10 @@
 # -*- coding: utf-8 -*-
 """Unit tests for CHLRScorer (src/pipeline/chlr_scorer.py)."""
 
-import pytest
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
+
+import pytest
 
 from src.pipeline.chlr_scorer import CHLRScorer
 

--- a/tests/unit/test_compressors.py
+++ b/tests/unit/test_compressors.py
@@ -9,16 +9,14 @@ Date: 2026-03-19
 """
 
 import sys
-import os
-import pytest
 from pathlib import Path
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import patch
 
 # 添加 src 目录到 path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
 
-from database import LobsterDatabase
 from dag_compressor import DAGCompressor
+from database import LobsterDatabase
 from incremental_compressor import IncrementalCompressor
 
 
@@ -145,7 +143,7 @@ class TestCompressorIntegration:
     def test_database_compressor_workflow(self):
         """测试数据库和压缩器工作流"""
         db = LobsterDatabase(":memory:")
-        compressor = DAGCompressor(db)
+        DAGCompressor(db)
 
         # 添加消息
         conv_id = "test_conv"

--- a/tests/unit/test_conflict_detector.py
+++ b/tests/unit/test_conflict_detector.py
@@ -2,8 +2,6 @@
 Unit tests for conflict detector module.
 """
 
-import pytest
-
 
 class TestConflictDetector:
     """Tests for ConflictDetector class."""
@@ -52,8 +50,9 @@ class TestConflictDetector:
 
     def test_reconcile_without_llm_client(self):
         """reconcile should fallback to message truncation without LLM."""
+        from unittest.mock import Mock
+
         from src.pipeline.conflict_detector import ConflictDetector, ConflictResult
-        from unittest.mock import Mock, MagicMock
 
         detector = ConflictDetector(use_nli=False)
 
@@ -91,8 +90,9 @@ class TestConflictDetector:
 
     def test_reconcile_with_llm_client(self):
         """reconcile should use LLM extraction when available."""
+        from unittest.mock import Mock
+
         from src.pipeline.conflict_detector import ConflictDetector, ConflictResult
-        from unittest.mock import Mock, MagicMock
 
         detector = ConflictDetector(use_nli=False)
 
@@ -132,9 +132,9 @@ class TestConflictDetector:
 
     def test_reconcile_marks_old_note_superseded(self):
         """reconcile should mark old note as superseded."""
-        from src.pipeline.conflict_detector import ConflictDetector, ConflictResult
         from unittest.mock import Mock
-        from datetime import datetime
+
+        from src.pipeline.conflict_detector import ConflictDetector, ConflictResult
 
         detector = ConflictDetector(use_nli=False)
 

--- a/tests/unit/test_context_engine.py
+++ b/tests/unit/test_context_engine.py
@@ -7,13 +7,13 @@ ContextEngine 集成测试（v3.3.0+）
 - 自动触发逻辑
 """
 
-import pytest
 import asyncio
-from unittest.mock import Mock, AsyncMock, MagicMock
-from pathlib import Path
 import sys
 import tempfile
-import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
 
 # 添加 src 到 path
 src_dir = Path(__file__).parent.parent.parent / "src"

--- a/tests/unit/test_dag_compressor.py
+++ b/tests/unit/test_dag_compressor.py
@@ -4,11 +4,12 @@
 
 import os
 import tempfile
+
 import pytest
 
+from src.dag_compressor import DAGCompressor
 from src.database import LobsterDatabase
 from src.llm_client import MockLLMClient
-from src.dag_compressor import DAGCompressor
 
 
 @pytest.fixture
@@ -197,7 +198,7 @@ class TestFullCompact:
         assert isinstance(result, dict)
 
     def test_compressed_message_ids_tracked(self, compressor, db):
-        ids = _seed(db, "c1", ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf"])
+        _seed(db, "c1", ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf"])
         compressor.full_compact("c1")
         compressed = compressor._get_compressed_message_ids("c1")
         # Some messages should be marked as compressed

--- a/tests/unit/test_dag_convergence.py
+++ b/tests/unit/test_dag_convergence.py
@@ -11,19 +11,20 @@ NOTE: These tests depend on Phase 2 (fix/phase2-dag-convergence) being merged fi
 Run after Phase 2 PR is merged to master.
 """
 
-import pytest
-import tempfile
 import os
-from pathlib import Path
-from datetime import datetime, timezone
 
 # 添加 src 到 path
 import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
 
-from database import LobsterDatabase
 from dag_compressor import DAGCompressor
+from database import LobsterDatabase
 
 
 class TestDagConvergence:
@@ -67,7 +68,7 @@ class TestDagConvergence:
         conversation_id = "test_conv"
 
         # 创建 12 个叶子摘要（应该生成 3 个 condensed 摘要，每个包含 4 个 leaf）
-        summary_ids = self._create_leaf_summaries(temp_db, conversation_id, 12)
+        self._create_leaf_summaries(temp_db, conversation_id, 12)
 
         # 执行压缩
         result = compressor.condensed_compact(conversation_id, depth=0, min_fanout=4)
@@ -87,14 +88,14 @@ class TestDagConvergence:
         for s in condensed_summaries:
             assert (
                 s["descendant_count"] == 40
-            ), f"每个 condensed 应该覆盖 40 条消息 (4 leaf * 10 msg)"
+            ), "每个 condensed 应该覆盖 40 条消息 (4 leaf * 10 msg)"
 
     def test_condensed_compact_respects_min_fanout(self, compressor, temp_db):
         """测试 condensed_compact 尊重 min_fanout"""
         conversation_id = "test_conv_2"
 
         # 只创建 3 个叶子摘要（小于 min_fanout=4）
-        summary_ids = self._create_leaf_summaries(temp_db, conversation_id, 3)
+        self._create_leaf_summaries(temp_db, conversation_id, 3)
 
         # 执行压缩
         result = compressor.condensed_compact(conversation_id, depth=0, min_fanout=4)
@@ -126,7 +127,7 @@ class TestDagConvergence:
         compressor.leaf_chunk_tokens = 1000  # 需要 1000 tokens 才触发压缩
 
         # 执行压缩
-        result = compressor.leaf_compact(conversation_id, max_tokens=1000)
+        _result = compressor.leaf_compact(conversation_id, max_tokens=1000)
 
         # 由于 episode tokens < max_tokens * 0.5 = 500，应该跳过
         # 但 total uncompressed tokens 也需要 >= max_tokens 才会触发

--- a/tests/unit/test_dual_decay.py
+++ b/tests/unit/test_dual_decay.py
@@ -8,11 +8,10 @@ Author: LobsterPress Team
 Date: 2026-04-05
 """
 
-import sys
 import math
-import pytest
-from pathlib import Path
+import sys
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
 

--- a/tests/unit/test_event_segmenter.py
+++ b/tests/unit/test_event_segmenter.py
@@ -2,8 +2,6 @@
 Unit tests for event segmenter module.
 """
 
-import pytest
-
 
 class TestEventSegmenter:
     """Tests for EventSegmenter class."""

--- a/tests/unit/test_hybrid_retriever.py
+++ b/tests/unit/test_hybrid_retriever.py
@@ -1,10 +1,7 @@
 """Unit tests for HybridRetriever - FTS5 + Vector → RRF → MMR → Time Decay pipeline."""
 
-import math
-import pytest
 from datetime import datetime, timedelta, timezone
-from unittest.mock import MagicMock, patch
-
+from unittest.mock import MagicMock
 
 from src.vector.retriever import HybridRetriever
 

--- a/tests/unit/test_incremental_compressor.py
+++ b/tests/unit/test_incremental_compressor.py
@@ -17,11 +17,12 @@ API facts confirmed by reading the source:
 
 import os
 import tempfile
+
 import pytest
 
 from src.database import LobsterDatabase
-from src.llm_client import MockLLMClient
 from src.incremental_compressor import IncrementalCompressor
+from src.llm_client import MockLLMClient
 
 
 @pytest.fixture

--- a/tests/unit/test_intent_extractor.py
+++ b/tests/unit/test_intent_extractor.py
@@ -2,9 +2,7 @@
 # -*- coding: utf-8 -*-
 """Unit tests for IntentExtractor (src/pipeline/intent_extractor.py)."""
 
-import pytest
-
-from src.pipeline.intent_extractor import IntentExtractor, Intent, Conclusion
+from src.pipeline.intent_extractor import Conclusion, Intent, IntentExtractor
 
 
 def _msg(role, content):

--- a/tests/unit/test_llm_providers.py
+++ b/tests/unit/test_llm_providers.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 """v3.2.0 多 LLM 提供商测试"""
 
-import sys
 import os
+import sys
 
 _project_root = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 sys.path.insert(0, os.path.join(_project_root, "src"))
 
-from src.llm_client import create_llm_client, get_llm_client, MockLLMClient
+from src.llm_client import MockLLMClient, create_llm_client, get_llm_client
 from src.llm_providers import get_provider_client
 
 
@@ -25,7 +25,7 @@ def test_mock_client():
     assert len(result) > 0
     assert client.is_available()
 
-    print(f"✅ Mock 客户端测试通过")
+    print("✅ Mock 客户端测试通过")
 
 
 def test_openai_client():
@@ -41,7 +41,7 @@ def test_openai_client():
     assert client.model == "gpt-4o-mini"
     assert client.is_available()
 
-    print(f"✅ OpenAI 客户端初始化成功")
+    print("✅ OpenAI 客户端初始化成功")
 
 
 def test_deepseek_client():
@@ -57,7 +57,7 @@ def test_deepseek_client():
     assert client.model == "deepseek-chat"
     assert client.is_available()
 
-    print(f"✅ DeepSeek 客户端初始化成功")
+    print("✅ DeepSeek 客户端初始化成功")
 
 
 def test_zhipu_client():
@@ -73,7 +73,7 @@ def test_zhipu_client():
     assert client.model == "glm-4-flash"
     assert client.is_available()
 
-    print(f"✅ 智谱 GLM 客户端初始化成功")
+    print("✅ 智谱 GLM 客户端初始化成功")
 
 
 def test_alibaba_client():
@@ -89,7 +89,7 @@ def test_alibaba_client():
     assert client.model == "qwen-turbo"
     assert client.is_available()
 
-    print(f"✅ 阿里通义千问客户端初始化成功")
+    print("✅ 阿里通义千问客户端初始化成功")
 
 
 def test_anthropic_client():
@@ -107,7 +107,7 @@ def test_anthropic_client():
     assert client.model == "claude-3-5-sonnet-20241022"
     assert client.is_available()
 
-    print(f"✅ Anthropic Claude 客户端初始化成功")
+    print("✅ Anthropic Claude 客户端初始化成功")
 
 
 def test_gemini_client():
@@ -123,7 +123,7 @@ def test_gemini_client():
     assert client.model == "gemini-pro"
     assert client.is_available()
 
-    print(f"✅ Google Gemini 客户端初始化成功")
+    print("✅ Google Gemini 客户端初始化成功")
 
 
 def test_mistral_client():
@@ -139,7 +139,7 @@ def test_mistral_client():
     assert client.model == "mistral-small-latest"
     assert client.is_available()
 
-    print(f"✅ Mistral 客户端初始化成功")
+    print("✅ Mistral 客户端初始化成功")
 
 
 def test_baidu_client():
@@ -161,7 +161,7 @@ def test_baidu_client():
     assert client.model == "ernie-speed-8k"
     assert client.is_available()
 
-    print(f"✅ 百度文心客户端初始化成功")
+    print("✅ 百度文心客户端初始化成功")
 
 
 def test_factory_function():
@@ -170,12 +170,12 @@ def test_factory_function():
 
     # 测试不支持的提供商
     try:
-        client = get_provider_client("unsupported_provider")
+        get_provider_client("unsupported_provider")
         assert False, "应该抛出 ValueError"
     except ValueError as e:
         assert "不支持的 LLM 提供商" in str(e)
 
-    print(f"✅ 工厂函数测试通过")
+    print("✅ 工厂函数测试通过")
 
 
 def test_environment_variable():
@@ -193,7 +193,7 @@ def test_environment_variable():
     assert client is not None
     assert isinstance(client, MockLLMClient)
 
-    print(f"✅ 环境变量配置测试通过")
+    print("✅ 环境变量配置测试通过")
 
 
 def test_graceful_fallback():
@@ -207,7 +207,7 @@ def test_graceful_fallback():
     assert client is not None
     assert isinstance(client, MockLLMClient)
 
-    print(f"✅ 优雅降级测试通过")
+    print("✅ 优雅降级测试通过")
 
 
 def main():

--- a/tests/unit/test_llm_summary.py
+++ b/tests/unit/test_llm_summary.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
 """v3.1.0 LLM 摘要功能测试"""
 
-import sys
 import os
+import sys
 
 _project_root = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 sys.path.insert(0, os.path.join(_project_root, "src"))
 
-from src.database import LobsterDatabase
 from src.dag_compressor import DAGCompressor
+from src.database import LobsterDatabase
 
 
 class MockLLMClient:

--- a/tests/unit/test_mcp_multi_agent.py
+++ b/tests/unit/test_mcp_multi_agent.py
@@ -4,10 +4,7 @@ Tests: lobster_memory_write_public, lobster_skill_search,
 lobster_skill_publish, lobster_skill_unpublish
 """
 
-import pytest
 import asyncio
-import hashlib
-from datetime import datetime
 
 
 def run_async(coro):

--- a/tests/unit/test_mcp_phase4.py
+++ b/tests/unit/test_mcp_phase4.py
@@ -5,11 +5,11 @@ Phase 4.4 MCP Tools Tests
 Tests for lobster_viewer and lobster_import tools
 """
 
-import pytest
 import asyncio
-import threading
 import time
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch
+
+import pytest
 
 
 def run_async(coro):
@@ -109,7 +109,7 @@ class TestHandleLobsterViewer:
         assert result["status"] == "running"
 
     def test_start_launches_server(self, server):
-        mock_db = Mock()
+        _mock_db = Mock()
         mock_viewer = Mock()
         mock_viewer.serve_forever = Mock()
 
@@ -122,7 +122,7 @@ class TestHandleLobsterViewer:
         mock_start.assert_called_once()
 
     def test_start_twice_fails(self, server):
-        mock_db = Mock()
+        _mock_db = Mock()
         mock_viewer = Mock()
         mock_viewer.serve_forever = Mock()
         server._viewer_server = mock_viewer

--- a/tests/unit/test_mcp_skill_tool.py
+++ b/tests/unit/test_mcp_skill_tool.py
@@ -2,7 +2,6 @@
 Unit tests for lobster_skill MCP tool.
 """
 
-import pytest
 import asyncio
 from unittest.mock import MagicMock, patch
 

--- a/tests/unit/test_migration_importer.py
+++ b/tests/unit/test_migration_importer.py
@@ -1,14 +1,11 @@
 # v5.0.0
 """OpenClaw 原生记忆导入器测试"""
 
-import pytest
-import json
 import hashlib
+import json
 import sqlite3
-import tempfile
 from pathlib import Path
-from unittest.mock import Mock, MagicMock, patch
-from datetime import datetime
+from unittest.mock import Mock
 
 from src.migration.importer import MemoryImporter
 
@@ -222,7 +219,7 @@ class TestImportMemories:
         importer = MemoryImporter(mock_db, openclaw_path=str(tmp_path))
 
         # 计算已处理的 hash
-        content_hash = hashlib.sha256("Hello".encode()).hexdigest()[:16]
+        _content_hash = hashlib.sha256("Hello".encode()).hexdigest()[:16]
 
         result = importer.import_memories(checkpoint_file=str(checkpoint_file))
 

--- a/tests/unit/test_owner_extension.py
+++ b/tests/unit/test_owner_extension.py
@@ -8,10 +8,9 @@ Author: lobster-press
 Date: 2026-04-05
 """
 
-import sys
 import os
+import sys
 import tempfile
-import pytest
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
@@ -148,8 +147,8 @@ class TestSearchWithOwner:
             conv_id = db.create_conversation()
 
             # 添加消息
-            msg1_id = db.add_message(conv_id, "user", "test message one")
-            msg2_id = db.add_message(conv_id, "assistant", "test message two")
+            db.add_message(conv_id, "user", "test message one")
+            db.add_message(conv_id, "assistant", "test message two")
 
             # 默认 owner = 'default'，应该能搜到
             results = db.search_messages("test")
@@ -202,7 +201,7 @@ class TestBackwardCompatibility:
 
             # 创建对话和消息
             conv_id = db.create_conversation()
-            msg_id = db.add_message(conv_id, "user", "hello world")
+            db.add_message(conv_id, "user", "hello world")
 
             # 验证消息能正常获取
             messages = db.get_messages(conv_id)

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -8,23 +8,22 @@ Date: 2026-03-19
 """
 
 import sys
-import pytest
 from pathlib import Path
 
 # 添加 src 目录到 path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
 
 from prompts import (
-    build_leaf_summary_prompt,
+    CONDENSED_SUMMARY_PROMPT,
+    CONFLICT_DETECTION_PROMPT,
+    LEAF_SUMMARY_PROMPT,
+    NOTE_EXTRACTION_PROMPT,
     build_condensed_summary_prompt,
-    build_note_extraction_prompt,
     build_conflict_detection_prompt,
+    build_leaf_summary_prompt,
+    build_note_extraction_prompt,
     estimate_tokens,
     truncate_messages,
-    LEAF_SUMMARY_PROMPT,
-    CONDENSED_SUMMARY_PROMPT,
-    NOTE_EXTRACTION_PROMPT,
-    CONFLICT_DETECTION_PROMPT,
 )
 
 

--- a/tests/unit/test_semantic_dedup.py
+++ b/tests/unit/test_semantic_dedup.py
@@ -8,8 +8,9 @@ Date: 2026-03-19
 """
 
 import sys
-import pytest
 from pathlib import Path
+
+import pytest
 
 # 添加 src 目录到 path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))

--- a/tests/unit/test_semantic_memory.py
+++ b/tests/unit/test_semantic_memory.py
@@ -2,9 +2,10 @@
 Unit tests for semantic memory module.
 """
 
-import pytest
-import tempfile
 import os
+import tempfile
+
+import pytest
 
 
 class TestSemanticMemory:

--- a/tests/unit/test_semantic_memory_v2.py
+++ b/tests/unit/test_semantic_memory_v2.py
@@ -7,17 +7,18 @@ Author: 小云 (Xiao Yun)
 Date: 2026-03-19
 """
 
-import sys
 import json
-import pytest
+import sys
 from pathlib import Path
-from unittest.mock import Mock, MagicMock
+from unittest.mock import Mock
+
+import pytest
 
 # 添加 src 目录到 path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
 
-from semantic_memory import SemanticMemory
 from database import LobsterDatabase
+from semantic_memory import SemanticMemory
 
 
 class TestSemanticMemoryInit:
@@ -33,7 +34,7 @@ class TestSemanticMemoryInit:
     def test_ensure_schema(self):
         """测试创建 schema"""
         db = LobsterDatabase(":memory:")
-        memory = SemanticMemory(db)
+        SemanticMemory(db)
 
         # 检查 notes 表是否存在
         db.cursor.execute("""

--- a/tests/unit/test_skill_evolver.py
+++ b/tests/unit/test_skill_evolver.py
@@ -2,10 +2,6 @@
 Unit tests for SkillEvolver class.
 """
 
-import pytest
-import hashlib
-from datetime import datetime
-
 
 class TestSkillEvolverConstant:
     """Tests for SkillEvolver constants."""
@@ -149,8 +145,8 @@ class TestLLMEvaluate:
 
     def test_llm_returns_yes(self):
         """LLM returns YES should result in True."""
-        from src.skills.evolver import SkillEvolver
         from src.llm_client import MockLLMClient
+        from src.skills.evolver import SkillEvolver
 
         mock_llm = MockLLMClient(response="YES")
         evolver = SkillEvolver(db=None, llm_client=mock_llm)
@@ -159,8 +155,8 @@ class TestLLMEvaluate:
 
     def test_llm_returns_no(self):
         """LLM returns NO should result in False."""
-        from src.skills.evolver import SkillEvolver
         from src.llm_client import MockLLMClient
+        from src.skills.evolver import SkillEvolver
 
         mock_llm = MockLLMClient(response="NO")
         evolver = SkillEvolver(db=None, llm_client=mock_llm)
@@ -181,8 +177,8 @@ class TestLLMEvaluate:
 
     def test_case_insensitive_yes(self):
         """YES in any case should be accepted."""
-        from src.skills.evolver import SkillEvolver
         from src.llm_client import MockLLMClient
+        from src.skills.evolver import SkillEvolver
 
         mock_llm = MockLLMClient(response="yes")
         evolver = SkillEvolver(db=None, llm_client=mock_llm)
@@ -195,8 +191,8 @@ class TestGenerateSkillMd:
 
     def test_with_llm_generates_skill_md(self):
         """With LLM should generate SKILL.md format."""
-        from src.skills.evolver import SkillEvolver
         from src.llm_client import MockLLMClient
+        from src.skills.evolver import SkillEvolver
 
         mock_llm = MockLLMClient(response="# Test Skill\n## 目标\nTest")
         evolver = SkillEvolver(db=None, llm_client=mock_llm)
@@ -446,8 +442,8 @@ class TestEvaluateAndGenerate:
 
     def test_llm_rejected_tasks_return_none(self):
         """LLM rejected tasks should return None."""
-        from src.skills.evolver import SkillEvolver
         from src.llm_client import MockLLMClient
+        from src.skills.evolver import SkillEvolver
 
         mock_llm = MockLLMClient(response="NO")
         evolver = SkillEvolver(db=None, llm_client=mock_llm)

--- a/tests/unit/test_skill_models.py
+++ b/tests/unit/test_skill_models.py
@@ -2,10 +2,6 @@
 Unit tests for skill models and database operations.
 """
 
-import pytest
-import json
-from datetime import datetime
-
 
 class TestSkillDataclass:
     """Tests for Skill dataclass."""
@@ -151,7 +147,7 @@ class TestDatabaseSkillTables:
     def test_skills_table_created(self, temp_db):
         """skills table should be created correctly."""
         temp_db.cursor.execute("""
-            SELECT name, type FROM sqlite_master 
+            SELECT name, type FROM sqlite_master
             WHERE type='table' AND name='skills'
         """)
         result = temp_db.cursor.fetchone()
@@ -161,7 +157,7 @@ class TestDatabaseSkillTables:
     def test_skill_versions_table_created(self, temp_db):
         """skill_versions table should be created correctly."""
         temp_db.cursor.execute("""
-            SELECT name, type FROM sqlite_master 
+            SELECT name, type FROM sqlite_master
             WHERE type='table' AND name='skill_versions'
         """)
         result = temp_db.cursor.fetchone()
@@ -171,7 +167,7 @@ class TestDatabaseSkillTables:
     def test_task_skills_table_created(self, temp_db):
         """task_skills table should be created correctly."""
         temp_db.cursor.execute("""
-            SELECT name, type FROM sqlite_master 
+            SELECT name, type FROM sqlite_master
             WHERE type='table' AND name='task_skills'
         """)
         result = temp_db.cursor.fetchone()
@@ -181,7 +177,7 @@ class TestDatabaseSkillTables:
     def test_skills_fts_virtual_table_created(self, temp_db):
         """skills_fts virtual table should be created."""
         temp_db.cursor.execute("""
-            SELECT name, type FROM sqlite_master 
+            SELECT name, type FROM sqlite_master
             WHERE type='table' AND name='skills_fts'
         """)
         result = temp_db.cursor.fetchone()
@@ -190,13 +186,13 @@ class TestDatabaseSkillTables:
     def test_skills_indexes_created(self, temp_db):
         """Skills indexes should be created."""
         temp_db.cursor.execute("""
-            SELECT name FROM sqlite_master 
+            SELECT name FROM sqlite_master
             WHERE type='index' AND name='idx_skills_owner'
         """)
         assert temp_db.cursor.fetchone() is not None
 
         temp_db.cursor.execute("""
-            SELECT name FROM sqlite_master 
+            SELECT name FROM sqlite_master
             WHERE type='index' AND name='idx_skill_versions'
         """)
         assert temp_db.cursor.fetchone() is not None

--- a/tests/unit/test_task_detector.py
+++ b/tests/unit/test_task_detector.py
@@ -2,7 +2,6 @@
 Unit tests for TaskDetector module.
 """
 
-import pytest
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock
 

--- a/tests/unit/test_tfidf_scorer.py
+++ b/tests/unit/test_tfidf_scorer.py
@@ -2,8 +2,6 @@
 Unit tests for TF-IDF scorer module.
 """
 
-import pytest
-
 
 class TestTFIDFScorer:
     """Tests for TFIDFScorer class."""

--- a/tests/unit/test_v400.py
+++ b/tests/unit/test_v400.py
@@ -9,10 +9,10 @@ Date: 2026-03-19
 """
 
 import sys
-import os
 import uuid
-import pytest
 from pathlib import Path
+
+import pytest
 
 # 添加 src 目录到 path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
@@ -176,7 +176,7 @@ class TestR3Mem:
         # Layer 1 展开（返回子摘要，对于叶子摘要应该返回空列表或自身）
         # 注意：expand_summary 的 target_layer=1 对于叶子摘要可能返回空列表
         # 因为叶子摘要没有子摘要
-        result = db.expand_summary(summary_id, target_layer=1)
+        _result = db.expand_summary(summary_id, target_layer=1)
         # 叶子摘要没有子摘要，所以返回空列表是正常的
         # 改为测试 target_layer=2（返回原始消息）
         result_layer2 = db.expand_summary(summary_id, target_layer=2)

--- a/tests/unit/test_vector_embedder.py
+++ b/tests/unit/test_vector_embedder.py
@@ -1,10 +1,8 @@
 """Unit tests for vector embedder module."""
 
-import pytest
-import numpy as np
-import os
 import tempfile
-import struct
+
+import numpy as np
 
 
 class TestNumpyOfflineEmbedder:
@@ -69,14 +67,14 @@ class TestCreateEmbedder:
 
     def test_falls_back_to_numpy_when_no_api_config(self):
         """Should fall back to NumpyOfflineEmbedder when no API config."""
-        from src.vector.embedder import create_embedder, NumpyOfflineEmbedder
+        from src.vector.embedder import NumpyOfflineEmbedder, create_embedder
 
         embedder = create_embedder()
         assert isinstance(embedder, NumpyOfflineEmbedder)
 
     def test_returns_openai_when_api_configured(self, monkeypatch):
         """Should return OpenAICompatibleEmbedder when API is configured."""
-        from src.vector.embedder import create_embedder, OpenAICompatibleEmbedder
+        from src.vector.embedder import OpenAICompatibleEmbedder, create_embedder
 
         monkeypatch.setenv("LOBSTER_EMBED_ENDPOINT", "http://localhost:8080")
         monkeypatch.setenv("LOBSTER_EMBED_API_KEY", "test-key")

--- a/tests/unit/test_viewer.py
+++ b/tests/unit/test_viewer.py
@@ -9,20 +9,15 @@ Date: 2026-04-05
 """
 
 import hashlib
-import json
 import io
+import json
 import sys
-import tempfile
-import os
+from http.server import HTTPServer
 from pathlib import Path
 from unittest.mock import MagicMock, patch
-from http.server import HTTPServer
-
-import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
 
-from database import LobsterDatabase
 from viewer.server import ViewerHandler, start_viewer
 
 


### PR DESCRIPTION
Comprehensive lint cleanup that was previously masked by `continue-on-error: true` in CI.

**Formatting fixes:**
- Run `black` on all 89 Python files
- Run `isort` on all files (consistent import ordering)
- Remove 87 unused imports (autoflake F401)
- Fix 51 f-strings without placeholders (F541 -> plain strings)
- Fix trailing whitespace (W291) and comment format (E265)

**Code fixes:**
- Remove unused variables with `_` prefix convention (F841)
- Add `from __future__ import annotations` + `Skill` import to database.py (F821)
- Add `.flake8` config for known safe ignores (E203=Black conflict, E402=sys.path structural, E501=managed by Black, F841=test assignments)

**CI fixes:**
- Remove all `continue-on-error` gates from test.yml — lint/test failures now properly block PRs